### PR TITLE
Fixes tap image upload functionality using signed URLs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,4 @@
-FROM node:lts-slim                                                                                                                           
-
-RUN apt-get update && apt-get install -y python2.7
-
-ENV PYTHON='/usr/bin/python'
+FROM node:12-slim
 
 WORKDIR /usr/src/app
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 FROM node:lts-slim                                                                                                                           
-  
+
+RUN apt-get update && apt-get install python3
+
 WORKDIR /usr/src/app
 
 COPY package*.json ./

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM node:lts-slim                                                                                                                           
 
-RUN apt-get update && apt-get install python3
+RUN apt-get update && apt-get install -y python3
 
 WORKDIR /usr/src/app
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,8 @@ FROM node:lts-slim
 
 RUN apt-get update && apt-get install -y python2.7
 
+ENV PYTHON='/usr/bin/python'
+
 WORKDIR /usr/src/app
 
 COPY package*.json ./

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM node:lts-slim                                                                                                                           
 
-RUN apt-get update && apt-get install -y python3
+RUN apt-get update && apt-get install -y python2.7
 
 WORKDIR /usr/src/app
 

--- a/package.json
+++ b/package.json
@@ -7,7 +7,6 @@
     "@fortawesome/free-brands-svg-icons": "^5.14.0",
     "@fortawesome/free-solid-svg-icons": "^5.14.0",
     "@fortawesome/react-fontawesome": "^0.1.11",
-    "aws-s3": "^2.0.5",
     "bootstrap": "^4.3.1",
     "firebase": "^6.2.0",
     "geolocation": "^0.2.0",

--- a/package.json
+++ b/package.json
@@ -63,5 +63,6 @@
     "not ie <= 11",
     "not op_mini all"
   ],
-  "homepage": "."
+  "homepage": ".",
+  "proxy": "https://test.phlask.me"
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2145,11 +2145,6 @@ ansi-styles@^4.1.0:
     "@types/color-name" "^1.1.1"
     color-convert "^2.0.1"
 
-any-base@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/any-base/-/any-base-1.1.0.tgz#ae101a62bc08a597b4c9ab5b7089d456630549fe"
-  integrity sha512-uMgjozySS8adZZYePpaWs8cxB9/kdzmpX6SgJZ+wbz1K5eYk5QMYDVJaZKhxyIHUdnnJkfR7SVgStgH7LkGUyg==
-
 anymatch@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/anymatch/-/anymatch-2.0.0.tgz#bcb24b4f37934d9aa7ac17b4adaf89e7c76ef2eb"
@@ -2395,14 +2390,6 @@ autoprefixer@^9.6.1:
     num2fraction "^1.2.2"
     postcss "^7.0.27"
     postcss-value-parser "^4.0.3"
-
-aws-s3@^2.0.5:
-  version "2.0.5"
-  resolved "https://registry.yarnpkg.com/aws-s3/-/aws-s3-2.0.5.tgz#6c13d9b152f750ba9e6d5d70bff68765d5849b1d"
-  integrity sha512-Sk/0Y2JZ+0NNznRrkbwA5KZmQoxGT++KhDkMp2eoY8RKJgIpekDInL0heFYj14u6AdLF/x0f0dCqtH1OcSHHRQ==
-  dependencies:
-    crypto-js "^3.1.9-1"
-    short-uuid "^3.1.0"
 
 aws-sign2@~0.7.0:
   version "0.7.0"
@@ -3577,11 +3564,6 @@ crypto-browserify@^3.11.0:
     public-encrypt "^4.0.0"
     randombytes "^2.0.0"
     randomfill "^1.0.3"
-
-crypto-js@^3.1.9-1:
-  version "3.3.0"
-  resolved "https://registry.yarnpkg.com/crypto-js/-/crypto-js-3.3.0.tgz#846dd1cce2f68aacfa156c8578f926a609b7976b"
-  integrity sha512-DIT51nX0dCfKltpRiXV+/TVZq+Qq2NgF4644+K7Ttnla7zEzqc+kjJyiB96BHNyUTBxyjzRcZYpUdZa+QAqi6Q==
 
 css-blank-pseudo@^0.1.4:
   version "0.1.4"
@@ -10620,14 +10602,6 @@ shellwords@^0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/shellwords/-/shellwords-0.1.1.tgz#d6b9181c1a48d397324c84871efbcfc73fc0654b"
   integrity sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==
-
-short-uuid@^3.1.0:
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/short-uuid/-/short-uuid-3.1.1.tgz#3ff427074b5fa7822c3793994d18a7a82e2f73a4"
-  integrity sha512-7dI69xtJYpTIbg44R6JSgrbDtZFuZ9vAwwmnF/L0PinykbFrhQ7V8omKsQcVw1TP0nYJ7uQp1PN6/aVMkzQFGQ==
-  dependencies:
-    any-base "^1.1.0"
-    uuid "^3.3.2"
 
 side-channel@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
Changed the upload approach to use POST requests via signed URLs instead of using the S3 library. The main benefit with this approach is that we can enforce the number of images loaded and unique filenames. I also made a change so that we have a different bucket and DB target for test vs beta vs production. That way we can test freely in each environment without interfering with the other environments.