### PR TITLE
Fixes Find Closest Tap button bug

### DIFF
--- a/src/components/IndieFoodMarker.js
+++ b/src/components/IndieFoodMarker.js
@@ -148,6 +148,11 @@ class IndieMarker extends React.Component{
                   position={{ lat: this.props.org.lat, lng: this.props.org.lon }}
                   icon={this.getIcon(this.props.org.access)}
                   infoIcon={this.getIcon(this.props.org.access,true)}
+                  // The lat and lon properties were added to support the object-based
+                  // setting for SET_SELECTED_PLACE redux action. Object structure consistency is needed in order
+                  // for getWalkingDurationAndTimes() in the SelectedTap component to work properly.
+                  lat={this.props.org.lat}
+                  lon={this.props.org.lon}
                 />
         </div>
       )

--- a/src/components/IndieMarker.js
+++ b/src/components/IndieMarker.js
@@ -138,6 +138,11 @@ class IndieMarker extends React.Component{
                   position={{ lat: this.props.tap.lat, lng: this.props.tap.lon }}
                   icon={this.getIcon(this.props.tap.access)}
                   infoIcon={this.getIcon(this.props.tap.access,true)}
+                  // The lat and lon properties were added to support the object-based
+                  // setting for SET_SELECTED_PLACE redux action. Object structure consistency is needed in order
+                  // for getWalkingDurationAndTimes() in the SelectedTap component to work properly.
+                  lat={this.props.tap.lat}
+                  lon={this.props.tap.lon}
                 />
         </div>
       )

--- a/src/components/SelectedTap.js
+++ b/src/components/SelectedTap.js
@@ -60,7 +60,7 @@ class SelectedTap extends React.Component {
   getWalkingDurationAndTimes = () => {
     const orsAPIKey = '5b3ce3597851110001cf6248ac903cdbe0364ca9850aa85cb64d8dfc';
     fetch(`https://api.openrouteservice.org/v2/directions/foot-walking?api_key=${orsAPIKey}&start=${this.props.userLocation.lng},
-    ${this.props.userLocation.lat}&end=${this.props.selectedPlace.position.lng},${this.props.selectedPlace.position.lat}`)
+    ${this.props.userLocation.lat}&end=${this.props.selectedPlace.lon},${this.props.selectedPlace.lat}`)
         .then(response => response.json())
         .then(data => {
             // duration is returned in seconds


### PR DESCRIPTION
Fixes a user-reported bug where using the "Find Closest Tap" button would break the site.

The root cause turned out to be a result of the fact that setting the currently selected tap (via the SET_SELECTED_PLACE redux action) can be done by two approaches, passing in an ID or an object. When we pass an ID, we then store an object reference to a location relative to our client-side copy of the tap/food DBs. When we pass an object, the object structure can be anything that is passed over.

After reviewing references to the setSelectedPlace() function, when we pass an object, we are passing a reference to the Marker element we are using to store the tap details. In that element, we store the lat/lng under a position property, which is what the getWalkingDurationAndTimes() function in the SelectedTap was originally looking for. In order to address this short term to fix functionality, we are simply adding the `lat` and `lon` properties to the Food/Water Marker objects and searching for those lat/lon properties, which will exist for both the Marker objects as well as DB items.