### PR TITLE
Misc: Create `schema.graphql` 

### DIFF
--- a/api/schema.graphql
+++ b/api/schema.graphql
@@ -1,0 +1,100 @@
+# Types = Sheet/Table in Excel
+type Example {
+  id: Int # fields are columns
+}
+
+enum Access {
+  PUBLIC
+  PRIVATE_SHARED
+  PRIVATE
+  RESTRICTED
+}
+
+enum YesNoUnsure {
+  YES
+  NO
+  UNSURE
+}
+
+interface SharedFields {
+  description: String
+  phlaskStatement: String
+  normsAndRules: String
+  website: String
+  additionalInfo: String
+}
+
+enum WaterTapTypes {
+    DRINKING_FOUNTAIN
+    BOTTLE_FILLER
+    SINK
+    SODA_FOUNTAIN
+    WATER_DISPENSER
+    WATER_COOLER
+    OTHER
+}
+
+type WaterTap implements SharedFields {
+  access: Access!
+  name: String!
+  address: String!
+  hours: [String] # array of hours of availbility -- each entry is day of week, [Monday Hours, Tuesday Hours, Wednesday...]
+  service: SELF_SERVE | ASK_PROPRIETOR | UNSURE
+  type: WaterTapTypes
+  filtration: YesNoUnsure
+  accessible: YesNoUnsure
+  sparkling: YesNoUnsure
+  vesselNeeded: YesNoUnsure
+  idRequired: YesNoUnsure
+}
+
+enum FoodAccess  {
+    GOVERNMENT
+    BUSINESS
+    NONPROFIT
+    RELIGIOUS
+    GRASSROOTS
+    OTHER
+}
+
+enum FoodConsumptionTypes {
+    ONSITE
+    TAKEAWAY
+    DELIVERY
+}
+
+type Food implements SharedFields {
+  access: FoodAccess!
+  name: String!
+  address: String!
+  hours: [String] # array of hours of availbility -- each entry is day of week, [Monday Hours, Tuesday Hours, Wednesday...]
+  consumption: FoodConsumptionTypes
+  foodType: [PERISHABLE | NONPERSIHABLE | PREPARED | OTHER]  # idk if this works
+  accessible: YesNoUnsure
+  idRequired: YesNoUnsure
+  minorsOnly: YesNoUnsure
+}
+
+enum ForagingFoodTypes {
+    NUT
+    FRUIT
+    LEAVES
+    BARK
+    FLOWERS
+    MUSHROOM
+    ROOT
+    OTHER
+}
+
+type Foraging implements SharedFields {
+  access: Access!
+  name: String!
+  address: String!
+  hours: [String] # array of hours of availbility -- each entry is day of week, [Monday Hours, Tuesday Hours, Wednesday...]
+  genus: String
+  species: String
+  features: [SWEET | SAVORY | MEDICINAL] # idk if this works
+  type: ForagingFoodTypes
+  accessible: YesNoUnsure
+}
+

--- a/api/schema.graphql
+++ b/api/schema.graphql
@@ -3,17 +3,24 @@ type Example {
   id: Int # fields are columns
 }
 
+type AvailabilityBlock {
+  open: String! # 24-hour formatted time, represented as 4 numbers (ex - 1300)
+  close: String! # 24-hour formatted time, represented as 4 numbers (ex - 1300)
+}
+
 enum Access {
   PUBLIC
   PRIVATE_SHARED
   PRIVATE
   RESTRICTED
+  WM # This is an older access type used for a limited-time event.
+  TRASH_ACADEMY # This is an older access type used for a limited-time event.
 }
 
 enum YesNoUnsure {
   YES
   NO
-  UNSURE
+  UNSURE # This is the default value when setting an argument of this type
 }
 
 interface SharedFields {
@@ -38,9 +45,9 @@ type WaterTap implements SharedFields {
   access: Access!
   name: String!
   address: String!
-  hours: [String] # array of hours of availbility -- each entry is day of week, [Monday Hours, Tuesday Hours, Wednesday...]
+  hours: [AvailabilityBlock] # array of hours of availbility -- each entry is day of week, [Sunday Hours, Monday Hours, Tuesday Hours...]
   service: SELF_SERVE | ASK_PROPRIETOR | UNSURE
-  type: WaterTapTypes
+  type: [WaterTapTypes]
   filtration: YesNoUnsure
   accessible: YesNoUnsure
   sparkling: YesNoUnsure
@@ -61,13 +68,14 @@ enum FoodConsumptionTypes {
     ONSITE
     TAKEAWAY
     DELIVERY
+    UNSURE # This is the default value when setting an argument of this type
 }
 
 type Food implements SharedFields {
   access: FoodAccess!
   name: String!
   address: String!
-  hours: [String] # array of hours of availbility -- each entry is day of week, [Monday Hours, Tuesday Hours, Wednesday...]
+  hours: [AvailabilityBlock] # array of hours of availbility -- each entry is day of week, [Sunday Hours, Monday Hours, Tuesday Hours...]
   consumption: FoodConsumptionTypes
   foodType: [PERISHABLE | NONPERSIHABLE | PREPARED | OTHER]  # idk if this works
   accessible: YesNoUnsure


### PR DESCRIPTION
# Pull Request

## What

Create a `graphql.schema` file that contains the fields and types for the crowdsourcing form

## Why

A way for developers/non-developers to view the schema without having to request access to the private Google Sheet. Has additional benefits that:
- schema is versioned control, so we can see how the data we're collecting has changed over time
- could serve as the one source of truth for our data moving forward, which might hopefully reduce developer friction moving forward