### PR TITLE
Update README documentation to include project structure and additional instructions for developing locally with Docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,37 @@
 
 Code behind the PHLASK Web Map
 
+## Project Structure
+
+```
+.
+├── Dockerfile                         <-- Dockerfile defining container for local dev and deploy
+├── README.md
+├── _phlask.code-workspace
+├── assets
+├── contributing.md
+├── cypress                            <-- Unit tests
+│   ├── fixtures                       <-- Fixtures for mocked out data
+│   └── integration                    <-- Source files for unit tests
+├── cypress.json
+├── docker-compose.yml
+├── package-lock.json
+├── package.json
+├── public
+├── src                                <-- Source files for project
+│   ├── App.js
+│   ├── actions                        <-- TODO
+│   ├── components                     <-- Source for all React components
+│   ├── firebase                       <-- TODO
+│   ├── helpers                        <-- TODO
+│   ├── hooks                          <-- Custom hooks
+│   ├── reducers                       <-- Redux reducers
+│   ├── selectors                      <-- TODO
+│   └── theme.js                       <-- Theme file for Material UI
+├── yarn-error.log
+└── yarn.lock
+```
+
 ## Running Locally
 
 ### Docker (Recommended path for consistency across computers)

--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ Code behind the PHLASK Web Map
     ```
       $ docker --version
       # something similar to below should be printed out
+      # older versions of Docker OK
       Docker version 20.10.12, build e91ed57
     ```
 

--- a/README.md
+++ b/README.md
@@ -67,7 +67,13 @@ Code behind the PHLASK Web Map
 
 1.  Run the container with docker-compose: `docker-compose up app`
 
-    Note: this may take awhile
+    Note: this may take awhile. Once the application is up, output similar to this should be printed out to the console:
+
+    ```
+    Project is running at http://172.21.112.1/
+    ...
+    Starting the development server...
+    ```
 
 1.  Navigate to localhost:3000 on your browser.
 

--- a/README.md
+++ b/README.md
@@ -21,13 +21,13 @@ Code behind the PHLASK Web Map
 ├── public
 ├── src                                <-- Source files for project
 │   ├── App.js
-│   ├── actions                        <-- TODO
+│   ├── actions                        <-- Source for all Redux actions
 │   ├── components                     <-- Source for all React components
-│   ├── firebase                       <-- TODO
-│   ├── helpers                        <-- TODO
+│   ├── firebase                       <-- Source for configurations used to connect to Firebase database
+│   ├── helpers                        <-- Helper functions shared across components/pages
 │   ├── hooks                          <-- Custom hooks
 │   ├── reducers                       <-- Redux reducers
-│   ├── selectors                      <-- TODO
+│   ├── selectors                      <-- Source for all Redux selectors
 │   └── theme.js                       <-- Theme file for Material UI
 ├── yarn-error.log
 └── yarn.lock

--- a/README.md
+++ b/README.md
@@ -41,9 +41,8 @@ Code behind the PHLASK Web Map
 
     - Follow installer instructions provided by Docker
 
-1.  Once installation is finished, confirm that docker has been installed successfully.
 1.  Open up a terminal (Powershell on Windows, Terminal on Mac, bash on Linux, or whatever your preferred terminal is)
-1.  Confirm Docker Desktop installed successfull: `docker --version`
+1.  Confirm Docker Desktop installed successful: `docker --version`
 
     Expected output:
 

--- a/README.md
+++ b/README.md
@@ -4,18 +4,42 @@ Code behind the PHLASK Web Map
 
 ## Running Locally
 
+### Docker (Recommended path for consistency across computers)
+
+1.  Download [Docker Desktop](https://www.docker.com/products/docker-desktop)
+
+    - Follow installer instructions provided by Docker
+
+1.  Once installation is finished, confirm that docker has been installed successfully.
+1.  Open up a terminal (Powershell on Windows, Terminal on Mac, bash on Linux, or whatever your preferred terminal is)
+1.  Confirm Docker Desktop installed successfull: `docker --version`
+
+    Expected output:
+
+    ```
+      $ docker --version
+      # something similar to below should be printed out
+      Docker version 20.10.12, build e91ed57
+    ```
+
+1.  Clone this repo: `git clone git@github.com:phlask/phlask-map.git`
+1.  Navigate to the root of the cloned repo: `cd phlask-map`
+1.  Build the container with docker-compose: `docker-compose build app`.
+
+    Note: this may take awhile
+
+1.  Run the container with docker-compose: `docker-compose up app`
+
+    Note: this may take awhile
+
+1.  Navigate to localhost:3000 on your browser.
+
 ### Yarn
 
 1. Ensure you have [nodejs v12.20.0](https://nodejs.org/download/release/v12.20.0/) installed on your machine
 1. Ensure you have [Yarn](https://yarnpkg.com/en/) installed on your machine
 1. Run `yarn install`
 1. Run `yarn start`
-
-### Docker (Recommended path for consistency across computers)
-
-1. You will need to have Docker installed: https://www.docker.com
-1. Once Docker is installed, run `docker-compose build app` and then `docker-compose up app` from the root of this repository.
-1. Navigate to localhost:3000 on your browser.
 
 ## Want to add something new or develop/report a fix for a bug you found?
 

--- a/README.md
+++ b/README.md
@@ -57,7 +57,13 @@ Code behind the PHLASK Web Map
 1.  Navigate to the root of the cloned repo: `cd phlask-map`
 1.  Build the container with docker-compose: `docker-compose build app`.
 
-    Note: this may take awhile
+    Note: this may take awhile. In the past this has taken ~5 minutes. If this step takes longer than 10 minutes, kill the process and try again. Final output should look like this:
+
+    ```
+    [+] Building 238.2s (12/12) FINISHED
+    ...
+    => => writing image sha256:c98c...
+    ```
 
 1.  Run the container with docker-compose: `docker-compose up app`
 


### PR DESCRIPTION
The title says it all.

Re-installed Docker Desktop on my Windows 10 machine and re-followed the instructions for setting up my development environment in Docker. Documented steps and results in Issue #240. Then I made updates to the README accordingly.

Also used `tree` utility to create a ASCII diagram of the project structure and added brief notes on relevant directories and files. Hopefully, this gets updated and used more often in the future as further developers come on board.

View visual diff of README with this link: https://github.com/phlask/phlask-map/pull/241/files?short_path=b335630#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5

Feel free to make comments on additional edits/additions to the documentation (or make the commits yourself `:D`)