### PR TITLE
minor refactor of getTaps and getFoodOrgs

### DIFF
--- a/src/actions/actions.js
+++ b/src/actions/actions.js
@@ -65,19 +65,20 @@ export const getTaps = () => dispatch => {
   const app = initializeApp(waterConfig, 'water');
   const database = getDatabase(app);
   return onValue(ref(database, "/"), (snapshot) => {
+      const snapshotVal = snapshot.val();
       var allTaps = [];
       var item;
-      for (item in snapshot.val()) {
-        if (snapshot.val()[item].access === "WM") {
+      for (item in snapshotVal) {
+        if (snapshotVal[item].access === "WM") {
           continue;
         }
-        if (snapshot.val()[item].active === "N") {
+        if (snapshotVal[item].active === "N") {
           continue;
         }
-        if (snapshot.val()[item].access === "TrashAcademy") {
+        if (snapshotVal[item].access === "TrashAcademy") {
           continue;
         }
-        allTaps.push(snapshot.val()[item]);
+        allTaps.push(snapshotVal[item]);
       }
       dispatch(getTapsSuccess(allTaps));
     }, {
@@ -95,10 +96,11 @@ export const getFoodOrgs = () => dispatch => {
   const app = initializeApp(foodConfig, 'food');
   const database = getDatabase(app);
   return onValue(ref(database, "/"), (snapshot) => {
+      const snapshotVal = snapshot.val();
       var allFoodOrgs = [];
       var item;
-      for (item in snapshot.val()) {
-        allFoodOrgs.push(snapshot.val()[item]);
+      for (item in snapshotVal) {
+        allFoodOrgs.push(snapshotVal[item]);
       }
       dispatch(getFoodSuccess(allFoodOrgs));
     });


### PR DESCRIPTION
# Pull Request

## Change Summary
In action.js in the functions getTaps and  getFoodOrgs instead of calling snapshot.val() multiple times inside of loop, refactored to call snapshot.val() only once and store the returned value as a variable, which can then be used inside the loop

## Change Reason
This change improves initial page load time by several seconds. It seems snapshot.val() is a relatively time-consuming function and it was being called a few hundred times inside of the getTaps() function. This refactor instead stores the value returned from firebase by snapshot.val() to a variable which can be accessed much more efficiently improving page load time

## Verification [Optional]

Lighthouse result before refactor:
![lighthouse-original](https://user-images.githubusercontent.com/42226213/176252805-16880496-b098-4e82-b933-52c93721daa7.png)

Lighthouse result after refactor:
![lighthouse-after-refactor](https://user-images.githubusercontent.com/42226213/176252871-927e0ee9-a970-4a2f-bfa5-b7dfe28a1d79.png)




Related Issue: #<Github Issue Number (if one exists)>

