### PR TITLE
refactor(map-markers): migrate map marker food to fc

### DIFF
--- a/src/components/MapMarkers/MapMarkersFood.js
+++ b/src/components/MapMarkers/MapMarkersFood.js
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import React from 'react';
 import { Marker } from 'google-maps-react';
 import { connect } from 'react-redux';
 import {
@@ -11,69 +11,35 @@ import makeGetVisibleTaps from '../../selectors/foodOrgSelectors';
 import foodIcon from '../images/food-marker-icons/food-site.png';
 import IndieFoodMarker from './IndieFoodMarker';
 
-export class MapMarkersFood extends Component {
-  UNSAFE_componentWillMount() {
-    if (!this.props.allFoodOrgs.length) {
-      this.props.getFoodOrgs();
+export function MapMarkersFood({
+  allFoodOrgs = [],
+  getFoodOrgs,
+  visibleTaps = [],
+  mapCenter,
+  google,
+  map
+}) {
+  React.useEffect(() => {
+    if (!allFoodOrgs.length && getFoodOrgs) {
+      getFoodOrgs();
     }
-  }
+  }, [allFoodOrgs, getFoodOrgs]);
 
-  shouldComponentUpdate(nextProps) {
-    return nextProps.visibleTaps === this.props.visibleTaps ? false : true;
-  }
-
-  getIcon(access) {
-    if (!this.props.accessTypesHidden.includes(access)) {
-      switch (access) {
-        case 'Food Site':
-          return require('../images/food-marker-icons/food-site.png');
-        case 'School':
-          return require('../images/food-marker-icons/school.png');
-        case 'Charter School':
-          return require('../images/food-marker-icons/charter-school.png');
-        case 'PHA Community Center':
-          return require('../images/food-marker-icons/pha.png');
-        default:
-          return '../images/foodIcon.png';
-      }
-    } else {
-      return { foodIcon };
-    }
-  }
-
-  onMarkerClick(org) {
-    this.props.toggleInfoWindow(true);
-    this.props.setSelectedPlace(org);
-    this.props.setMapCenter(org.position);
-  }
-
-  render() {
-    // console.log("rendered MapMarkers")
-    if (this.props.visibleTaps) {
-      if (this.props) {
-        return (
-          <React.Fragment>
-            <Marker
-              map={this.props.map}
-              google={this.props.google}
-              key="current_pos"
-              name={'Current Pos'}
-              position={this.props.mapCenter}
-              // onClick={this.onMarkerClick}
-            />
-            {this.props.visibleTaps.map((org, index) => (
-              <IndieFoodMarker
-                key={index}
-                org={org}
-                google={this.props.google}
-                map={this.props.map}
-              />
-            ))}
-          </React.Fragment>
-        );
-      }
-    } else return null;
-  }
+  if (!visibleTaps?.length) return null;
+  return (
+    <>
+      <Marker
+        map={map}
+        google={google}
+        key="current_pos"
+        name="Current Pos"
+        position={mapCenter}
+      />
+      {visibleTaps.map((org, index) => (
+        <IndieFoodMarker key={index} org={org} google={google} map={map} />
+      ))}
+    </>
+  );
 }
 
 const makeMapStateToProps = () => {
@@ -98,4 +64,13 @@ const mapDispatchToProps = {
   setMapCenter
 };
 
-export default connect(makeMapStateToProps, mapDispatchToProps)(MapMarkersFood);
+export default connect(
+  makeMapStateToProps,
+  mapDispatchToProps
+)(
+  React.memo(
+    MapMarkersFood,
+    (prevProps, nextProps) =>
+      prevProps.visibleTaps?.length === nextProps.visibleTaps?.length
+  )
+);


### PR DESCRIPTION
# Pull Request

## Change Summary

- Migrated the MapMarkersFood.js component from class to function component
- Used React.memo in order to prevent re-renders of the center map marker (previously used with the "shouldComponentUpdate" lifecycle method)
- Used useEffect in order to conditionally fetch food orgs if not available (previously used the "UNSAFE_componentWillMount" lifecycle method
- Removed unused methods

## Change Reason

According to issue #277, we are reducing our usage of class based components, which are part of an old React API and harder to maintain.

## Verification [Optional]
Provided a gif in the comments


Related Issue: #277