### PR TITLE
refactor(map-markers-water): migrate to fc

### DIFF
--- a/src/components/MapMarkers/MapMarkers.js
+++ b/src/components/MapMarkers/MapMarkers.js
@@ -10,148 +10,34 @@ import {
 } from '../../actions/actions';
 import makeGetVisibleTaps from '../../selectors/tapSelectors';
 
-export class MapMarkers extends Component {
-  state = {
-    shouldUpdate: true
-  };
+export function MapMarkers({
+  allTaps = [],
+  visibleTaps = [],
+  getTaps,
+  map,
+  google,
+  mapCenter
+}) {
+  React.useEffect(() => {
+    if (!allTaps.length && getTaps) getTaps();
+  }, [allTaps, getTaps]);
 
-  UNSAFE_componentWillMount() {
-    if (!this.props.allTaps.length) {
-      this.props.getTaps();
-    }
-  }
-
-  shouldComponentUpdate(nextProps) {
-    return nextProps.visibleTaps === this.props.visibleTaps
-      ? false
-      : this.state.shouldUpdate;
-  }
-
-  // Prevent from updating after initial loading of Markers
-  componentDidUpdate() {
-    this.setState({
-      shouldUpdate: false
-    });
-    // console.log("MM update");
-  }
-
-  getIcon(access) {
-    if (!this.props.accessTypesHidden.includes(access)) {
-      switch (access) {
-        case 'Public':
-          return require('../images/tap-marker-icons/Public.png');
-        case 'Private-Shared':
-          return require('../images/tap-marker-icons/Shared.png');
-        case 'Private':
-          return require('../images/tap-marker-icons/Private.png');
-        case 'Restricted':
-          return require('../images/tap-marker-icons/Restricted.png');
-        case 'Semi-public':
-          return require('../images/tap-marker-icons/Shared.png');
-        case 'TrashAcademy':
-          return 'https://i.imgur.com/fXTeEKL.png';
-        default:
-          return 'https://i.imgur.com/kKXG3TO.png';
-      }
-    } else {
-      return 'https://i.imgur.com/kKXG3TO.png';
-    }
-  }
-
-  // onMarkerClick(tap){
-  //   this.props.toggleInfoWindow(true);
-  //   this.props.setSelectedPlace(tap);
-  //   this.props.setMapCenter(tap.position);
-  // }
-
-  render() {
-    // console.log(this.props)
-    if (this.props.visibleTaps) {
-      return (
-        <React.Fragment>
-          <Marker
-            map={this.props.map}
-            google={this.props.google}
-            key="current_pos"
-            name={'Current Pos'}
-            position={this.props.mapCenter}
-          />
-          {this.props.visibleTaps.map((tap, index) => (
-            <IndieMarker
-              key={index}
-              tap={tap}
-              google={this.props.google}
-              map={this.props.map}
-              // onMarkerClick={this.onMarkerClick.bind(this)}
-              // getIcon={this.getIcon}
-              // accessTypesHidden={this.props.accessTypesHidden}
-            />
-          ))}
-        </React.Fragment>
-      );
-    } else return null;
-  }
+  if (!visibleTaps.length) return null;
+  return (
+    <>
+      <Marker
+        map={map}
+        google={google}
+        key="current_pos"
+        name="Current Pos"
+        position={mapCenter}
+      />
+      {visibleTaps.map((tap, index) => (
+        <IndieMarker key={index} tap={tap} google={google} map={map} />
+      ))}
+    </>
+  );
 }
-
-// class Markers extends React.Component{
-
-//   shouldComponentUpdate(nextProps){
-
-//   }
-
-//   getIcon(access) {
-//     if (!this.props.accessTypesHidden.includes(access)) {
-//       switch (access) {
-//         case "Public":
-//           return require('./images/tap-marker-icons/Public.png')
-//         case "Private-Shared":
-//           return require('./images/tap-marker-icons/Shared.png')
-//         case "Private":
-//           return require('./images/tap-marker-icons/Private.png')
-//         case "Restricted":
-//           return require('./images/tap-marker-icons/Restricted.png')
-//         case "Semi-public":
-//           return require('./images/tap-marker-icons/Shared.png')
-//         case "TrashAcademy":
-//           return "https://i.imgur.com/fXTeEKL.png";
-//         default:
-//           return "https://i.imgur.com/kKXG3TO.png";
-//       }
-//     } else {
-//       return "https://i.imgur.com/kKXG3TO.png";
-//     }
-//   }
-
-//   render(){
-//     return(
-//       <Marker
-//                 access={this.props.tap.access}
-//                 map={this.props.map}
-//                 google={this.props.google}
-//                 mapCenter={this.props.mapCenter}
-//                 key={this.props.key}
-//                 name={this.props.tap.tapnum}
-//                 organization={this.props.tap.organization}
-//                 address={this.props.tap.address}
-//                 hours={this.props.tap.hours}
-//                 description={this.props.tap.description}
-//                 filtration={this.props.tap.filtration}
-//                 handicap={this.props.tap.handicap}
-//                 service={this.props.tap.service}
-//                 sparkling={"sparkling" in this.props.tap ? this.props.tap.sparkling : "no"}
-//                 tap_type={this.props.tap.tap_type}
-//                 norms_rules={this.props.tap.norms_rules}
-//                 vessel={this.props.tap.vessel}
-//                 img={this.props.tap.images}
-//                 onClick={this.props.onMarkerClick.bind(this)}
-//                 position={{ lat: this.props.tap.lat, lng: this.props.tap.lon }}
-//                 icon={{
-//                   url: this.getIcon(this.props.tap.access)
-//                 }}
-//               />
-//     )
-//   }
-// }
 
 const makeMapStateToProps = () => {
   const getVisibleTaps = makeGetVisibleTaps();
@@ -175,4 +61,13 @@ const mapDispatchToProps = {
   setMapCenter
 };
 
-export default connect(makeMapStateToProps, mapDispatchToProps)(MapMarkers);
+export default connect(
+  makeMapStateToProps,
+  mapDispatchToProps
+)(
+  React.memo(
+    MapMarkers,
+    (prevState, nextState) =>
+      prevState.visibleTaps.length === nextState.visibleTaps.length
+  )
+);


### PR DESCRIPTION
# Pull Request

## Change Summary

- Migrated the MapMarkers.js component from class to function component
- Used React.memo in order to prevent re-renders of the center map marker (previously used with the "shouldComponentUpdate" lifecycle method)
- Used useEffect in order to conditionally fetch food orgs if not available (previously used the "UNSAFE_componentWillMount" lifecycle method
- Removed unused methods

## Change Reason

According to issue https://github.com/phlask/phlask-map/issues/277, we are reducing our usage of class based components, which are part of an old React API and harder to maintain.

## Verification [Optional]

![phlask-markers](https://user-images.githubusercontent.com/45559220/187564285-5cb971df-e1a7-41dc-a31b-4eeef782c725.gif)


Related Issue: #277 

