### PR TITLE
Remove Map Centering on Marker Click

### DIFF
--- a/src/components/IndieMarker/IndieMarker.js
+++ b/src/components/IndieMarker/IndieMarker.js
@@ -121,9 +121,9 @@ class IndieMarker extends React.Component {
         .getProjection()
         .fromPointToLatLng(worldCoordinateNewCenter);
       const newLatlng = { lat: newCenter.lat(), lng: newCenter.lng() };
-      this.props.setMapCenter(newLatlng);
+      // this.props.setMapCenter(newLatlng);
     } else {
-      this.props.setMapCenter(tap.position);
+      // this.props.setMapCenter(tap.position);
     }
   }
 

--- a/src/components/MapMarkers/IndieFoodMarker.js
+++ b/src/components/MapMarkers/IndieFoodMarker.js
@@ -139,9 +139,9 @@ class IndieMarker extends React.Component {
         .getProjection()
         .fromPointToLatLng(worldCoordinateNewCenter);
       const newLatlng = { lat: newCenter.lat(), lng: newCenter.lng() };
-      this.props.setMapCenter(newLatlng);
+      // this.props.setMapCenter(newLatlng);
     } else {
-      this.props.setMapCenter(org.position);
+      // this.props.setMapCenter(org.position);
     }
   }
 


### PR DESCRIPTION
# Pull Request

## Change Summary
Remove map re-centering when a marker is clicked.

## Change Reason
Issue #270 270
Related Issue: #270 