### PR TITLE
Issue 270 - Stop Centering on Resource Change & Marker Click

### DIFF
--- a/src/components/IndieMarker/IndieMarker.js
+++ b/src/components/IndieMarker/IndieMarker.js
@@ -5,13 +5,12 @@ import {
   getTaps,
   toggleInfoWindow,
   setSelectedPlace,
-  setMapCenter
+  setMapCenter,
 } from '../../actions/actions';
 import makeGetVisibleTaps from '../../selectors/tapSelectors';
 import './IndieMarker.css';
 import phlaskMarkerIcon from '../icons/PhlaskMarkerIcon';
 import phlaskFilterIcon from '../icons/PhlaskFilterIcon';
-import { isMobile } from 'react-device-detect';
 
 class IndieMarker extends React.Component {
   state = {
@@ -85,46 +84,6 @@ class IndieMarker extends React.Component {
   onMarkerClick(tap) {
     this.props.toggleInfoWindow(true);
     this.props.setSelectedPlace(tap);
-    //this.props.setMapCenter(tap.position);
-    if (isMobile) {
-      // https://stackoverflow.com/questions/10656743/how-to-offset-the-center-point-in-google-maps-api-v3
-      const latlng = new this.props.google.maps.LatLng(
-        tap.position.lat,
-        tap.position.lng
-      );
-      const offsetx = 0;
-      // offset by half the height of modal minus height of the marker icon
-      let modalHeight = 0;
-      try {
-        modalHeight = document.getElementById(
-          'tap-info-container-mobile'
-        ).offsetHeight;
-      } catch (error) {
-        console.log(
-          'There was an error getting element in IndieMarker. This was lazily fixed for now.'
-        );
-      }
-      const offsety = Math.floor(modalHeight / 2 - 20);
-      var scale = Math.pow(2, this.props.map.getZoom());
-      var worldCoordinateCenter = this.props.map
-        .getProjection()
-        .fromLatLngToPoint(latlng);
-      var pixelOffset = new this.props.google.maps.Point(
-        offsetx / scale || 0,
-        offsety / scale || 0
-      );
-      var worldCoordinateNewCenter = new this.props.google.maps.Point(
-        worldCoordinateCenter.x - pixelOffset.x,
-        worldCoordinateCenter.y + pixelOffset.y
-      );
-      var newCenter = this.props.map
-        .getProjection()
-        .fromPointToLatLng(worldCoordinateNewCenter);
-      const newLatlng = { lat: newCenter.lat(), lng: newCenter.lng() };
-      this.props.setMapCenter(newLatlng);
-    } else {
-      this.props.setMapCenter(tap.position);
-    }
   }
 
   render() {

--- a/src/components/MapMarkers/IndieFoodMarker.js
+++ b/src/components/MapMarkers/IndieFoodMarker.js
@@ -18,7 +18,6 @@ import FoodSchoolFilterIcon from '../icons/FoodSchoolFilterIcon';
 import FoodRecreationFilterIcon from '../icons/FoodRecreationFilterIcon';
 import FoodCongregationFilterIcon from '../icons/FoodCongregationFilterIcon';
 import '../IndieMarker/IndieMarker.css';
-import { isMobile } from 'react-device-detect';
 
 class IndieMarker extends React.Component {
   state = {
@@ -110,39 +109,6 @@ class IndieMarker extends React.Component {
   onMarkerClick(org) {
     this.props.toggleInfoWindow(true);
     this.props.setSelectedPlace(org);
-    //this.props.setMapCenter(org.position);
-    if (isMobile) {
-      // https://stackoverflow.com/questions/10656743/how-to-offset-the-center-point-in-google-maps-api-v3
-      const latlng = new this.props.google.maps.LatLng(
-        org.position.lat,
-        org.position.lng
-      );
-      const offsetx = 0;
-      // offset by half the height of modal minus height of the marker icon
-      const modalHeight = document.getElementById(
-        'tap-info-container-mobile'
-      ).offsetHeight;
-      const offsety = Math.floor(modalHeight / 2 - 20);
-      var scale = Math.pow(2, this.props.map.getZoom());
-      var worldCoordinateCenter = this.props.map
-        .getProjection()
-        .fromLatLngToPoint(latlng);
-      var pixelOffset = new this.props.google.maps.Point(
-        offsetx / scale || 0,
-        offsety / scale || 0
-      );
-      var worldCoordinateNewCenter = new this.props.google.maps.Point(
-        worldCoordinateCenter.x - pixelOffset.x,
-        worldCoordinateCenter.y + pixelOffset.y
-      );
-      var newCenter = this.props.map
-        .getProjection()
-        .fromPointToLatLng(worldCoordinateNewCenter);
-      const newLatlng = { lat: newCenter.lat(), lng: newCenter.lng() };
-      this.props.setMapCenter(newLatlng);
-    } else {
-      this.props.setMapCenter(org.position);
-    }
   }
 
   render() {

--- a/src/components/ReactGoogleMaps/ReactGoogleMaps.js
+++ b/src/components/ReactGoogleMaps/ReactGoogleMaps.js
@@ -287,8 +287,6 @@ export class ReactGoogleMaps extends Component {
   };
 
   render() {
-    console.log(this.state.currlat, this.state.currlon);
-
     return (
       <div id="react-google-map" className={styles.mapContainer}>
         {/* <ClosestTap/> */}

--- a/src/components/ReactGoogleMaps/ReactGoogleMaps.js
+++ b/src/components/ReactGoogleMaps/ReactGoogleMaps.js
@@ -162,6 +162,7 @@ export class ReactGoogleMaps extends Component {
       anchor: false
     };
     this.toggleDrawer = this.toggleDrawer.bind(this);
+    this.onDragEnd = this.onDragEnd.bind(this);
   }
 
   // UNSAFE_componentWillReceiveProps(nextProps) {
@@ -175,15 +176,6 @@ export class ReactGoogleMaps extends Component {
       this.setState({
         unfilteredTaps: prevProps.tapsDisplayed
       });
-      if (
-        this.state.currlat !== this.props.mapCenter.lat ||
-        this.state.currlon !== this.props.mapCenter.lng
-      ) {
-        this.setState({
-          currlat: this.props.mapCenter.lat,
-          currlon: this.props.mapCenter.lng
-        });
-      }
     }
   }
 
@@ -253,6 +245,13 @@ export class ReactGoogleMaps extends Component {
     }
   };
 
+  onDragEnd = (_, map) => {
+    this.setState({
+      currlat: map.center.lat(),
+      currlon: map.center.lng(),
+    });
+  }
+
   toggleTapInfo = isExpanded => {
     this.setState({
       isExpanded: isExpanded
@@ -288,7 +287,7 @@ export class ReactGoogleMaps extends Component {
   };
 
   render() {
-    // console.log("Rendered ReactGoogleMaps");
+    console.log(this.state.currlat, this.state.currlon);
 
     return (
       <div id="react-google-map" className={styles.mapContainer}>
@@ -305,6 +304,7 @@ export class ReactGoogleMaps extends Component {
               mapTypeControl={false}
               rotateControl={false}
               fullscreenControl={false}
+              onDragend={this.onDragEnd}
               initialCenter={{
                 lat: this.state.currlat,
                 lng: this.state.currlon


### PR DESCRIPTION
# Pull Request

This is a much cleaner way to accomplish the fix utilizing onDragend hook.

## Change Summary

- Removed logic in IndieFoodMarker and IndieMarker to center map on click.
- In ReactGoogleMaps, remember the coordinates of where the user drags/pans to before re-rendering the `<Map>`.

## Change Reason

Undesired behavior

Related Issue: #270 

