### PR TITLE
Adds support for Redux Devtools and Redux Guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,17 +85,24 @@ Code behind the PHLASK Web Map
 1. Run `yarn install`
 1. Run `yarn start`
 
-## Recommended Development tools
+## Recommended Development Tools
 
-### Code formatting
+### Code Formatting
 
 We use Prettier to ensure a consistent code formatting across the project, if you are running VSCode, please make sure to install the [Prettier extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode), the project configuration will ensure that Prettier is set as your default formatter as well.
+
+### Redux State Viewing
+During development, you may need to make changes to components which interact with Redux state. If you would like to have a better idea of the values in the Redux state while in development, install the Redux DevTools using the instructions here: https://github.com/reduxjs/redux-devtools/tree/main/extension#installation
+
+For a guide on how to use the extension check the [Docs section of their documentation](https://github.com/reduxjs/redux-devtools/tree/main/extension#docs). This video in particular may be useful: https://egghead.io/lessons/javascript-getting-started-with-redux-dev-tools
+
+For more information on how to understand/use the PHLASK Map Redux state, see our [Redux Guide](redux_guide.md)
 
 ## Want to add something new or develop/report a fix for a bug you found?
 
 See our [Contribution Guide](contributing.md) to learn about our branching strategy and issue reporting etiquette, and more!
 
-## Branching strategy
+## Branching Strategy
 
 ![png](assets/images/phlaskgitPipelines.png)
 
@@ -114,8 +121,15 @@ The PHLASK Map runs on a static page built with:
 
 - ReactJS (https://reactjs.org)
   - Builds the static content that composes the map page
+- Redux (https://redux.js.org/)
+  - Provides a single state which is accessible across the application.
+  - This is used to simplify passing state properties when they need to be modified by child/sibling components.
+  - For more information on how to understand/use our Redux state, see our [Redux Guide](redux_guide.md)
+- Material UI (https://mui.com/)
+  - Provides pre-built components and simplifies consistent styling across the project
 - React Bootstrap (https://react-bootstrap.netlify.com)
   - Provides pre-built components with Bootstrap-styling baked-in
+  - NOTE: This is currently on-track for deprecation in our project in favor of Material UI
 - GitHub Actions (https://github.com/features/actions)
   - Runs the required compute to build the site on ReactJS
 

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "@fortawesome/react-fontawesome": "^0.1.11",
     "@mui/material": "^5.6.2",
     "@mui/icons-material": "5.4.2",
+    "@reduxjs/toolkit": "^1.8.2",
     "bootstrap": "^5.1.3",
     "cypress": "^9.5.4",
     "firebase": "^9.6.11",

--- a/redux_guide.md
+++ b/redux_guide.md
@@ -1,0 +1,42 @@
+# Redux Guide
+## Purpose
+The purpose of this guide is to instruct developers of the PHLASK Map project on how to interact with the Redux state used throughout the site. A deep understanding of how Redux generally works is out of scope for this document, as that has been covered by the wider dev community.
+
+## Why Redux?
+The main is Redux was chosen very early on (2019) into our transition to React was to simplify passing state properties when they need to be modified by child/sibling components. The team's understanding of React was immature at the time, but we were struggling with the idea of passing properties. We had a lot of unrelated components that interact with all of the tap data, and we want the tap data to be stored locally in order to minimize the amount of pulls from Firebase. Storing the tap data in Redux state allowed us to pass references to the taps via their IDs and then pull any additional data by interacting with the central Redux state.
+
+## How is the Redux state used?
+### Initialization
+In order to start up the state, we call the `store` function in `index.js` as a property of the `Provider` component. This exposes the state to everything contained under that Provider component. Since it is the top-level component for the site, it is available to all components.
+
+### Initial State
+The initial state is defined in `store.js`. This file defines:
+- Use of Redux Thunk to enable async interactions with Redux state: https://github.com/reduxjs/redux-thunk
+- Use of `reducers/filterMarkers.js` as the definition of the state structure.
+    - `initialState` - Defines the properties for the Redux state
+    - `case actions.ACTION_NAME` - Defines the different actions available to interact with the state and how they behave when invoked.
+    - For more information about reducers, read: https://redux.js.org/tutorials/essentials/part-1-overview-concepts#reducers
+
+### Manipulating the state
+The `actions/actions.js` file defines the actions that can be performed by components to manipulate the state. For more information about actions, read: https://redux.js.org/tutorials/essentials/part-1-overview-concepts#actions
+
+Actions are referenced in components via two different approaches, depending on how the component is built:
+#### Functional Components
+For an example of how class based components interact with Redux state, check `components/Head/Head.js`.
+- `const dispatch = useDispatch();` is added to the function in order to enable the use of Redux dispatches. These are the functions from `actions/actions.js` which can be triggered to manipulate state.
+    - For information about Redux dispatches, see: https://redux.js.org/tutorials/essentials/part-1-overview-concepts#dispatch
+    - This is used within the functional component by calling the `dispatch` function with the following properties
+        - `type` - The type value defined in `actions/actions.js`
+        - `property_name` - Additional properties defined for the action with the `type` property with value of `type`.
+- `const property_name = useSelector(state => state.redux_state_property)` is used to reference Redux state.
+
+#### Class Based Components
+**NOTE:** We are gradually deprecating this approach in favor of functional components. This subsection is included while the deprecation is underway.
+For an example of how class based components interact with Redux state, check `components/SearchBar/SearchBar.js`.
+- A top-level `const mapStateToProps` is defined to map Redux state properties to properties that should be set in the component.
+    - To interact with these proprties within the component class, use `this.props.property_name`
+- A top-level `const mapDispatchToProps` is defined to map Redux dispatches. These are the functions from `actions/actions.js` which can be triggered to manipulate state.
+    - For information about Redux dispatches, see: https://redux.js.org/tutorials/essentials/part-1-overview-concepts#dispatch
+    - These functions should be imported using standard javascript imports.
+    - To interact with dispatches within the component class, use `this.props.function_name`
+- A top-level export of the component is arranged such that it uses the `connect()` redux function to connect the component class to the Redux state store.

--- a/src/actions/actions.js
+++ b/src/actions/actions.js
@@ -7,12 +7,6 @@ import {
   waterConfig
 } from '../firebase/firebaseConfig';
 
-export const RESIZE_WINDOW = 'RESIZE_WINDOW';
-export const resizeWindow = size => ({
-  type: RESIZE_WINDOW,
-  size
-});
-
 export const SET_TOGGLE_STATE = 'SET_TOGGLE_STATE';
 export const setToggleState = (toggle, toggleState) => ({
   type: SET_TOGGLE_STATE,

--- a/src/actions/actions.js
+++ b/src/actions/actions.js
@@ -55,6 +55,7 @@ export const getTaps = () => dispatch => {
     snapshot => {
       const snapshotVal = snapshot.val();
       // TODO: Clean up Firebase DB for this one-off edge case
+      // NOTE: The code block below is filtering out tap with access-types that are no longer used
       var allTaps = snapshotVal.filter(
         key =>
           key.access != 'WM' &&

--- a/src/components/IndieMarker/IndieMarker.js
+++ b/src/components/IndieMarker/IndieMarker.js
@@ -11,6 +11,7 @@ import makeGetVisibleTaps from '../../selectors/tapSelectors';
 import './IndieMarker.css';
 import phlaskMarkerIcon from '../icons/PhlaskMarkerIcon';
 import phlaskFilterIcon from '../icons/PhlaskFilterIcon';
+import { cleanUpForRedux } from '../MapMarkers/utils';
 
 class IndieMarker extends React.Component {
   state = {
@@ -83,7 +84,7 @@ class IndieMarker extends React.Component {
 
   onMarkerClick(tap) {
     this.props.toggleInfoWindow(true);
-    this.props.setSelectedPlace(tap);
+    this.props.setSelectedPlace(cleanUpForRedux(tap));
   }
 
   render() {

--- a/src/components/MapMarkers/IndieFoodMarker.js
+++ b/src/components/MapMarkers/IndieFoodMarker.js
@@ -18,6 +18,7 @@ import FoodSchoolFilterIcon from '../icons/FoodSchoolFilterIcon';
 import FoodRecreationFilterIcon from '../icons/FoodRecreationFilterIcon';
 import FoodCongregationFilterIcon from '../icons/FoodCongregationFilterIcon';
 import '../IndieMarker/IndieMarker.css';
+import { cleanUpForRedux } from './utils';
 
 class IndieMarker extends React.Component {
   state = {
@@ -108,7 +109,7 @@ class IndieMarker extends React.Component {
 
   onMarkerClick(org) {
     this.props.toggleInfoWindow(true);
-    this.props.setSelectedPlace(org);
+    this.props.setSelectedPlace(cleanUpForRedux(org));
   }
 
   render() {

--- a/src/components/MapMarkers/MapMarkersFood.js
+++ b/src/components/MapMarkers/MapMarkersFood.js
@@ -8,7 +8,6 @@ import {
   setMapCenter
 } from '../../actions/actions';
 import makeGetVisibleTaps from '../../selectors/foodOrgSelectors';
-import foodIcon from '../images/food-marker-icons/food-site.png';
 import IndieFoodMarker from './IndieFoodMarker';
 
 export function MapMarkersFood({

--- a/src/components/MapMarkers/utils.js
+++ b/src/components/MapMarkers/utils.js
@@ -1,0 +1,6 @@
+// This function cleans up properties from marker objects passed to Redux
+// This is done to prevent large and unused properties from overloading state
+export const cleanUpForRedux = (markerObject) => {
+    const {map, google, onClick: _, ...cleanedObject} = markerObject;
+    return cleanedObject
+}

--- a/src/reducers/filterMarkers.js
+++ b/src/reducers/filterMarkers.js
@@ -105,7 +105,7 @@ export default (state = initialState, act) => {
       };
 
     case actions.SET_FILTER_FUNCTION:
-      console.log('set filter func');
+      // console.log('set filter func');
       return { filterFunction: !state.filterFunction, ...state };
 
     case actions.TOGGLE_SEARCH_BAR:

--- a/src/reducers/filterMarkers.js
+++ b/src/reducers/filterMarkers.js
@@ -2,7 +2,6 @@ import * as actions from '../actions/actions';
 import { isMobile } from 'react-device-detect';
 
 const initialState = {
-  screenSize: '',
   mapCenter: {
     lat: parseFloat('39.952744'),
     lng: parseFloat('-75.163500')
@@ -39,11 +38,6 @@ const initialState = {
 
 export default (state = initialState, act) => {
   switch (act.type) {
-    case actions.RESIZE_WINDOW:
-      return () => {
-        // console.log("Resize: " + act.size);
-      };
-
     case actions.SET_TOGGLE_STATE:
       return {
         ...state,

--- a/src/store.js
+++ b/src/store.js
@@ -1,7 +1,16 @@
-import { createStore, applyMiddleware } from 'redux';
-import thunk from 'redux-thunk';
-import filterMarkers from './reducers/filterMarkers';
+import { createStore, applyMiddleware, compose } from "redux";
+import thunk from "redux-thunk";
+import filterMarkers from "./reducers/filterMarkers";
 
-const store = createStore(filterMarkers, applyMiddleware(thunk));
+const composeEnhancers =
+  window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__({
+    trace: true,
+    traceLimit: 25,
+  }) || compose;
+
+const store = createStore(
+  filterMarkers,
+  composeEnhancers(applyMiddleware(thunk))
+);
 
 export default store;

--- a/src/store.js
+++ b/src/store.js
@@ -2,10 +2,18 @@ import { createStore, applyMiddleware, compose } from "redux";
 import thunk from "redux-thunk";
 import filterMarkers from "./reducers/filterMarkers";
 
+// const actionSanitizer = (action) =>
+// action.type === "GET_TAPS_SUCCESS" && action.data
+// ? { ...action, data: "<<LONG_BLOB>>" }
+// : action;
+
 const composeEnhancers =
   window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__({
     trace: true,
     traceLimit: 25,
+    // actionSanitizer,
+    // stateSanitizer: (state) =>
+    // state.data ? { ...state, data: "<<LONG_BLOB>>" } : state,
   }) || compose;
 
 const store = createStore(

--- a/src/store.js
+++ b/src/store.js
@@ -2,18 +2,18 @@ import { createStore, applyMiddleware, compose } from "redux";
 import thunk from "redux-thunk";
 import filterMarkers from "./reducers/filterMarkers";
 
-// const actionSanitizer = (action) =>
-// action.type === "GET_TAPS_SUCCESS" && action.data
-// ? { ...action, data: "<<LONG_BLOB>>" }
-// : action;
+const actionSanitizer = (action) =>
+  action.type === "GET_TAPS_SUCCESS" && action.data
+    ? { ...action, data: "<<LONG_BLOB>>" }
+    : action;
 
 const composeEnhancers =
   window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__({
     trace: true,
     traceLimit: 25,
-    // actionSanitizer,
-    // stateSanitizer: (state) =>
-    // state.data ? { ...state, data: "<<LONG_BLOB>>" } : state,
+    actionSanitizer,
+    stateSanitizer: (state) =>
+      state.data ? { ...state, data: "<<LONG_BLOB>>" } : state,
   }) || compose;
 
 const store = createStore(

--- a/src/store.js
+++ b/src/store.js
@@ -1,24 +1,10 @@
-import { createStore, applyMiddleware, compose } from "redux";
 import thunk from "redux-thunk";
 import filterMarkers from "./reducers/filterMarkers";
+import { configureStore } from "@reduxjs/toolkit";
 
-const actionSanitizer = (action) =>
-  action.type === "GET_TAPS_SUCCESS" && action.data
-    ? { ...action, data: "<<LONG_BLOB>>" }
-    : action;
-
-const composeEnhancers =
-  window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__({
-    trace: true,
-    traceLimit: 25,
-    actionSanitizer,
-    stateSanitizer: (state) =>
-      state.data ? { ...state, data: "<<LONG_BLOB>>" } : state,
-  }) || compose;
-
-const store = createStore(
-  filterMarkers,
-  composeEnhancers(applyMiddleware(thunk))
-);
+const store = configureStore({
+  reducer: filterMarkers,
+  middleware: (getDefaultMiddleware) => getDefaultMiddleware([thunk]),
+});
 
 export default store;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2209,6 +2209,16 @@
   dependencies:
     "@babel/runtime" "^7.6.2"
 
+"@reduxjs/toolkit@^1.8.2":
+  version "1.8.2"
+  resolved "https://registry.yarnpkg.com/@reduxjs/toolkit/-/toolkit-1.8.2.tgz#352fd17bc858af51d21ce8d28183a930cab9e638"
+  integrity sha512-CtPw5TkN1pHRigMFCOS/0qg3b/yfPV5qGCsltVnIz7bx4PKTJlGHYfIxm97qskLknMzuGfjExaYdXJ77QTL0vg==
+  dependencies:
+    immer "^9.0.7"
+    redux "^4.1.2"
+    redux-thunk "^2.4.1"
+    reselect "^4.1.5"
+
 "@restart/hooks@^0.4.0", "@restart/hooks@^0.4.6":
   version "0.4.7"
   resolved "https://registry.yarnpkg.com/@restart/hooks/-/hooks-0.4.7.tgz#d79ca6472c01ce04389fc73d4a79af1b5e33cd39"
@@ -8993,7 +9003,7 @@ redux-thunk@^2.4.1:
   resolved "https://registry.yarnpkg.com/redux-thunk/-/redux-thunk-2.4.1.tgz#0dd8042cf47868f4b29699941de03c9301a75714"
   integrity sha512-OOYGNY5Jy2TWvTL1KgAlVy6dcx3siPJ1wTq741EPyUKfn6W6nChdICjZwCd0p8AZBs5kWpZlbkXW2nE/zjUa+Q==
 
-redux@^4.2.0:
+redux@^4.1.2, redux@^4.2.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/redux/-/redux-4.2.0.tgz#46f10d6e29b6666df758780437651eeb2b969f13"
   integrity sha512-oSBmcKKIuIR4ME29/AeNUnl5L+hvBq7OaJWzaptTQJAntaPvxIJqfnjbaEiCzzaIz+XmVILfqAM3Ob0aXLPfjA==


### PR DESCRIPTION
# Pull Request

## Change Summary

- Adds support for Redux Devtools (thanks @edlopez000 !)
- Adds a guide to help new joiners learn how Redux is used in our project

## Change Reason

A recurring theme during onboarding is that it is difficult to understand how to interact with the Redux state or how it affects different parts of the application. The availability of Devtools helps developers see the state and its changes as they interact with the application.

## Verification [Optional]

![2023-03-05 20-46-43](https://user-images.githubusercontent.com/2278918/223005398-241e9014-3ff1-401f-ba94-69471e34c00c.gif)


Related Issue: #271 

