### PR TITLE
Task 302: Create V.2 SearchBar (Desktop)

### DIFF
--- a/src/components/ReactGoogleMaps/ReactGoogleMaps.js
+++ b/src/components/ReactGoogleMaps/ReactGoogleMaps.js
@@ -2,6 +2,7 @@ import { Map, GoogleApiWrapper, Marker } from 'google-maps-react';
 import React, { Component } from 'react';
 import ReactTouchEvents from 'react-touch-events';
 import SearchBar from '../SearchBar/SearchBar';
+import TutorialModal from '../TutorialModal/TutorialModal';
 import styles from './ReactGoogleMaps.module.scss';
 import { connect } from 'react-redux';
 import SelectedTap from '../SelectedTap/SelectedTap';
@@ -23,6 +24,7 @@ import MapMarkersFood from '../MapMarkers/MapMarkersFood';
 import { isMobile } from 'react-device-detect';
 import Toolbar from '../Toolbar/Toolbar';
 import MapMarkersMapper from '../MapMarkers/MapMarkersMapper';
+import Stack from '@mui/material/Stack';
 
 // // Actual Magic: https://stackoverflow.com/a/41337005
 // // Distance calculates the distance between two lat/lon pairs
@@ -248,9 +250,9 @@ export class ReactGoogleMaps extends Component {
   onDragEnd = (_, map) => {
     this.setState({
       currlat: map.center.lat(),
-      currlon: map.center.lng(),
+      currlon: map.center.lng()
     });
-  }
+  };
 
   toggleTapInfo = isExpanded => {
     this.setState({
@@ -342,10 +344,15 @@ export class ReactGoogleMaps extends Component {
           </div>
         </ReactTouchEvents>
         <div className={styles.searchBarContainer}>
-          <SearchBar
-            className="searchBar"
-            search={location => this.searchForLocation(location)}
-          />
+          <Stack direction="row">
+            <SearchBar
+              className="searchBar"
+              search={location => this.searchForLocation(location)}
+            />
+            <TutorialModal
+              showButton={isMobile ? !this.state.isSearchBarShown : true}
+            />
+          </Stack>
         </div>
         <Toolbar />
         <SelectedTap></SelectedTap>

--- a/src/components/ReactGoogleMaps/ReactGoogleMaps.js
+++ b/src/components/ReactGoogleMaps/ReactGoogleMaps.js
@@ -343,8 +343,8 @@ export class ReactGoogleMaps extends Component {
             </Map>
           </div>
         </ReactTouchEvents>
-        <div className={styles.searchBarContainer}>
-          <Stack direction="row">
+        <Stack position="absolute" bottom="0px" height="143px" width="34%">
+          <Stack direction="row" spacing={2}>
             <SearchBar
               className="searchBar"
               search={location => this.searchForLocation(location)}
@@ -353,8 +353,8 @@ export class ReactGoogleMaps extends Component {
               showButton={isMobile ? !this.state.isSearchBarShown : true}
             />
           </Stack>
-        </div>
-        <Toolbar />
+          <Toolbar />
+        </Stack>
         <SelectedTap></SelectedTap>
       </div>
     );

--- a/src/components/ReactGoogleMaps/ReactGoogleMaps.module.scss
+++ b/src/components/ReactGoogleMaps/ReactGoogleMaps.module.scss
@@ -1,6 +1,6 @@
 .searchBarContainer {
   position: relative;
-  top: 57px;
+  top: 608px;
 }
 
 .mapContainer {

--- a/src/components/ReactGoogleMaps/ReactGoogleMaps.module.scss
+++ b/src/components/ReactGoogleMaps/ReactGoogleMaps.module.scss
@@ -1,6 +1,7 @@
 .searchBarContainer {
-  position: relative;
-  top: 608px;
+  position: absolute;
+  width: 34%;
+  bottom: 75px;
 }
 
 .mapContainer {

--- a/src/components/SearchBar/SearchBar.js
+++ b/src/components/SearchBar/SearchBar.js
@@ -14,7 +14,6 @@ import {
 } from '@fortawesome/free-solid-svg-icons';
 import Input from '@mui/material/Input';
 import InputAdornment from '@mui/material/InputAdornment';
-import TutorialModal from '../TutorialModal/TutorialModal';
 import SearchIcon from '@mui/icons-material/Search';
 
 class SearchBar extends React.Component {
@@ -158,10 +157,6 @@ class SearchBar extends React.Component {
             />
           </button>
         )}
-
-        <TutorialModal
-          showButton={isMobile ? !this.state.isSearchBarShown : true}
-        />
       </>
     );
   }

--- a/src/components/SearchBar/SearchBar.js
+++ b/src/components/SearchBar/SearchBar.js
@@ -12,7 +12,10 @@ import {
   faSearchLocation,
   faChevronLeft
 } from '@fortawesome/free-solid-svg-icons';
+import Input from '@mui/material/Input';
+import InputAdornment from '@mui/material/InputAdornment';
 import TutorialModal from '../TutorialModal/TutorialModal';
+import SearchIcon from '@mui/icons-material/Search';
 
 class SearchBar extends React.Component {
   constructor(props) {
@@ -86,13 +89,18 @@ class SearchBar extends React.Component {
                   }`}
                 >
                   {/* type="search" is only HTML5 compliant */}
-                  <input
+                  <Input
                     {...getInputProps({
-                      placeholder: 'Search For Taps Near...'
+                      placeholder: 'Search For Resources Near...'
                     })}
                     className={`${styles.searchInput} form-control`}
                     type="search"
                     ref={this.state.refSearchBar}
+                    startAdornment={
+                      <InputAdornment position="start">
+                        <SearchIcon />
+                      </InputAdornment>
+                    }
                   />
                   {loading && (
                     <div className={styles.autocompleteDropdown}>

--- a/src/components/SearchBar/SearchBar.module.scss
+++ b/src/components/SearchBar/SearchBar.module.scss
@@ -1,7 +1,7 @@
 .desktopSearch {
   display: flex;
   flex-direction: row;
-  width: 100%;
+  width: 84%;
   justify-content: flex-start;
   padding: 1rem 0 0 1rem;
   pointer-events: none;

--- a/src/components/TutorialModal/TutorialModal.module.scss
+++ b/src/components/TutorialModal/TutorialModal.module.scss
@@ -39,9 +39,9 @@
 .infoButton {
   max-width: 30px;
   max-height: 30px;
-  position: absolute;
-  top: 2rem;
-  right: 4rem;
+  position: relative;
+  top: 1.5rem;
+  right: 0.5rem;
   border-radius: 50%;
   background-color: white;
 

--- a/src/components/TutorialModal/TutorialModal.module.scss
+++ b/src/components/TutorialModal/TutorialModal.module.scss
@@ -40,8 +40,8 @@
   max-width: 30px;
   max-height: 30px;
   position: absolute;
-  top: 1rem;
-  right: 1rem;
+  top: 2rem;
+  right: 4rem;
   border-radius: 50%;
   background-color: white;
 


### PR DESCRIPTION
# Pull Request

## Change Summary

Moved Search bar to the bottom of the page, on top of the toolbar. Also moved information button slightly to the left. Since it's in the same container as the search bar, it would have overlapped with the zoom buttons if it wasn't moved since I moved the container down

## Change Reason

Implementing task 302: Create V.2 SearchBar (Desktop)

## Verification [Optional]


New Look:

![image](https://github.com/phlask/phlask-map/assets/8428783/5f41293d-5053-4b0d-9a36-4782dc0af9f3)

Related Issue: #302 

