### PR TITLE
Feature: Add search bar for mobile v2

### DIFF
--- a/src/components/Head/Head.js
+++ b/src/components/Head/Head.js
@@ -8,6 +8,7 @@ import { ReactComponent as PhlaskIcon } from '../icons/PHLASK_v2.svg';
 import { ReactComponent as SearchIcon } from '../icons/SearchIcon.svg';
 import { ReactComponent as SlidersIcon } from '../icons/SlidersIcon.svg';
 import SideBar from '../SideBar/SideBar';
+import zIndex from '@mui/material/styles/zIndex';
 
 export default function Head() {
   const dispatch = useDispatch();
@@ -23,8 +24,8 @@ export default function Head() {
 
   const toggleSearchBar = () => {
     dispatch({
-      type: 'TOGGLE_SEARCH_BAR'
-      // isShown: !isSearchShown
+      type: 'TOGGLE_SEARCH_BAR',
+      isShown: true
     });
   };
 
@@ -54,14 +55,14 @@ export default function Head() {
         setOpen={setSidebarOpen}
         showControls={setShowMapControls}
       />
-      <AppBar>
+      <AppBar sx={{zIndex: 1}}>
         <Toolbar
           sx={{
             backgroundColor: '#fff',
             color: '#fff',
             boxShadow:
               '0 1px 0 rgba(0, 0, 0, 0.12), 0 1px 0 rgba(0, 0, 0, 0.24)',
-            display: 'flex'
+            display: 'flex',
           }}
         >
           <IconButton

--- a/src/components/ReactGoogleMaps/ReactGoogleMaps.js
+++ b/src/components/ReactGoogleMaps/ReactGoogleMaps.js
@@ -161,7 +161,8 @@ export class ReactGoogleMaps extends Component {
       filteredTaps: [],
       zoom: 16,
       searchedTap: null,
-      anchor: false
+      anchor: false,
+      isSearchShown: false,
     };
     this.toggleDrawer = this.toggleDrawer.bind(this);
     this.onDragEnd = this.onDragEnd.bind(this);
@@ -343,18 +344,16 @@ export class ReactGoogleMaps extends Component {
             </Map>
           </div>
         </ReactTouchEvents>
-        <Stack position="absolute" bottom="0px" height="143px" width="34%">
+        {this.props.isSearchShown &&  <div className={styles.popupBackground}/>}
+        <Stack position="absolute" top={isMobile && "70px"} bottom={!isMobile && "0px"} height={!isMobile && "143px"} width={isMobile ? "100%": "34%"}>
           <Stack direction="row" spacing={2}>
             <SearchBar
               className="searchBar"
               search={location => this.searchForLocation(location)}
             />
-            <TutorialModal
-              showButton={isMobile ? !this.state.isSearchBarShown : true}
-            />
           </Stack>
           <Toolbar />
-        </Stack>
+         </Stack>
         <SelectedTap></SelectedTap>
       </div>
     );
@@ -369,7 +368,8 @@ const mapStateToProps = state => ({
   filterFunction: state.filterFunction,
   mapCenter: state.mapCenter,
   phlaskType: state.phlaskType,
-  showingInfoWindow: state.showingInfoWindow
+  showingInfoWindow: state.showingInfoWindow,
+  isSearchShown: state.isSearchShown
   // infoIsExpanded: state.infoIsExpanded
 });
 

--- a/src/components/ReactGoogleMaps/ReactGoogleMaps.module.scss
+++ b/src/components/ReactGoogleMaps/ReactGoogleMaps.module.scss
@@ -8,3 +8,11 @@
   position: relative;
   height: 100%;
 }
+
+.popupBackground {
+  background-color: rgba(0, 0, 0, 0.2);
+  height: 100vh;
+  position: fixed;
+  width: 100vw;
+  z-index: 10;
+}

--- a/src/components/SearchBar/SearchBar.module.scss
+++ b/src/components/SearchBar/SearchBar.module.scss
@@ -5,6 +5,7 @@
   justify-content: flex-start;
   padding: 1rem 0 0 1rem;
   pointer-events: none;
+  z-index: 20;
 
   .searchBarContainer {
     width: 30vw;
@@ -37,6 +38,7 @@
   justify-content: flex-start;
   padding: 1rem 0 0 1rem;
   pointer-events: none;
+  z-index: 20;
 
   .searchBarContainer {
     width: 100%;
@@ -78,16 +80,18 @@
 }
 
 .mobileCloseButton {
+  background-color: white;
+  border-radius: 5px;
   position: relative;
-  margin: 0 0.5rem;
-  height: 40px;
-  width: 40px;
-  padding: 0 10px;
+  margin: 0 1rem;
+  width: 50px;
+  padding: 0 15px;
   animation-name: close-button-animation;
   animation-duration: 0.6s;
   animation-fill-mode: forwards;
   animation-timing-function: ease-in-out;
   pointer-events: visibleStroke;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2), 0 -1px 0px rgba(0, 0, 0, 0.02);
 }
 @keyframes close-button-animation {
   0% {
@@ -97,7 +101,7 @@
     opacity: 0;
   }
   100% {
-    opacity: 0.5;
+    opacity: 1;
   }
 }
 

--- a/src/components/Toolbar/Toolbar.js
+++ b/src/components/Toolbar/Toolbar.js
@@ -189,7 +189,6 @@ function Toolbar(props) {
 
   return (
     <>
-      $
       {!isMobile ? (
         <div
           className={`${styles.toolbar} ${
@@ -268,7 +267,8 @@ function Toolbar(props) {
             right: 0,
             pb: '25px',
             pt: '10px',
-            bgcolor: 'white'
+            bgcolor: 'white',
+            zIndex: 20,
           }}
         >
           <BottomNavigation showLabels>

--- a/src/components/Toolbar/Toolbar.module.scss
+++ b/src/components/Toolbar/Toolbar.module.scss
@@ -6,6 +6,7 @@ $foodColor: #8dc63f;
   display: flex;
   background-color: white;
   box-shadow: 0 0 20px rgba(0, 0, 0, 0.3);
+  z-index: 20;
 
   img {
     height: 100%;


### PR DESCRIPTION
# Pull Request

## Change Summary

Render search bar when search icon is pressed on mobile view
- Add a popup overlay for the search bar 
- Refactor search bar from class to function
- Add a trigger on the search icon to open the search bar
- Add z-index for header, footer, and the search bar

## Change Reason

Update the search bar to work for mobile V2 UI/UX

## Verification [Optional]

![image](https://github.com/phlask/phlask-map/assets/14133613/6fde9f17-0841-4671-b684-192083cc18c1)

![image](https://github.com/phlask/phlask-map/assets/14133613/b2ee2da8-9337-4cf7-b7d6-01c2e56aa053)


Related Issue: #228

