### PR TITLE
Codespace config

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,8 @@
+{
+  "image": "mcr.microsoft.com/devcontainers/universal:2",
+  "features": {
+    "ghcr.io/devcontainers/features/node:1": {
+      "version": "16"
+    }
+  }
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,5 +4,16 @@
     "ghcr.io/devcontainers/features/node:1": {
       "version": "16"
     }
+  },
+  "postCreateCommand": "yarn install",
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "esbenp.prettier-vscode"
+      ]
+    },
+    "codespaces": {
+      "openFiles": ["README.md"]
+    }
   }
 }

--- a/.eslintignore
+++ b/.eslintignore
@@ -5,6 +5,7 @@ cypress/
 
 # Build directory
 docker/
+build/
 
 # Unused files
 Legend.js

--- a/README.md
+++ b/README.md
@@ -36,7 +36,30 @@ Code behind the PHLASK Web Map
 
 ## Running Locally
 
-### Docker (Recommended path for consistency across computers)
+### GitHub Codespaces
+
+[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/phlask/phlask-map/tree/develop?quickstart=1)
+
+GitHub Codespaces provides you with a remote development environment without needing to install anything locally. You can also connect to your Codespace from VSCode, if desired. A default codespace configuration in the `.devcontainer/devcontainer.json` file has been prepared that will ensure your codespace has everything needed to run PHLASK. Once the codespace has started, you should be able to use the Terminal window in the bottom to run `yarn start`. That will load a local development copy of the PHLASK site for you to test with.
+
+To learn more about Codespaces, review this page: https://github.com/features/codespaces
+
+As of this writing, PHLASK does not fund these codespaces. However, GitHub offers up to 60 hours/month of free use for codespaces. For more details on Codespace pricing, review this page: https://docs.github.com/en/billing/managing-billing-for-github-codespaces/about-billing-for-github-codespaces#monthly-included-storage-and-core-hours-for-personal-accounts
+
+Note that `core hours per month` means each core on your codespace consumes independent hours from your code hour limit. If you choose a 2-core space (sufficient for PHLASK), you use 2 core-hours every hour from the free `core hours per month` allowance.
+
+### Yarn
+
+1. Ensure you have [nodejs v16](https://nodejs.org/download/release/latest-v16.x/) installed on your machine.
+   - You can also use use [nvm](https://github.com/nvm-sh/nvm/tree/master#install--update-script).
+   - once you have install nvm
+   - run `nvm install` <- this will download the required verison (only required on the first installation)
+   - run `nvm use` sets that to the active version of node in your terminal
+1. Ensure you have [Yarn](https://yarnpkg.com/en/) installed on your machine
+1. Run `yarn install`
+1. Run `yarn start`
+
+### Docker
 
 1.  Download [Docker Desktop](https://www.docker.com/products/docker-desktop)
 
@@ -77,17 +100,6 @@ Code behind the PHLASK Web Map
     ```
 
 1.  Navigate to localhost:3000 on your browser.
-
-### Yarn
-
-1. Ensure you have [nodejs v16](https://nodejs.org/download/release/latest-v16.x/) installed on your machine.
-   - You can also use use [nvm](https://github.com/nvm-sh/nvm/tree/master#install--update-script).
-   - once you have install nvm
-   - run `nvm install` <- this will download the required verison (only required on the first installation)
-   - run `nvm use` sets that to the active version of node in your terminal
-1. Ensure you have [Yarn](https://yarnpkg.com/en/) installed on your machine
-1. Run `yarn install`
-1. Run `yarn start`
 
 ## Recommended Development Tools
 


### PR DESCRIPTION
# Pull Request

## Change Summary

Adds an easier option for users to get started developing PHLASK via GitHub codespaces.

## Change Reason

As onboarding can require spending a lot of time guiding users on how to set up a local development environment, the use of GitHub Codespaces can help reduce some of that time. This will allow developers newer to software development to get started sooner and spend less time figuring out how to set up the tools to do the development, allowing us to make more use of the time on our limited weekly meetups.

## Verification [Optional]

No video was recorded, but you can easily try it out yourself by clicking the Codespaces link in the README. 😄 

Related Issue: N/A

