### PR TITLE
[Issue 357] Remove extraneous marker from map

### DIFF
--- a/src/components/MapMarkers/MapMarkers.js
+++ b/src/components/MapMarkers/MapMarkers.js
@@ -31,13 +31,6 @@ const MapMarkers = ({
 
   return (
     <>
-      <Marker
-        map={map}
-        google={google}
-        key="current_pos"
-        name="Current Pos"
-        position={mapCenter}
-      />
       {visibleTaps.map((tap, index) => {
         if (
           filterHelper(


### PR DESCRIPTION
# Pull Request

Fix for #357 (see issue for full context)

## Change Summary

Dug into this issue more, and I found that two markers aren't actually appearing for a search - what's happening is that when the map and your location loads, there is a default pin being placed at the center of your map.

I looked at the history of the code that caused this, and it's been there for a long time (the last change to that block of code was a year ago during a refactor) so I can't determine if the change is intentional or not. I personally think it doesn't make much sense to show their current location as a pin - instead we might want to enable a blue dot indicator or some other smaller icon.

## Change Reason

Change fixes a bug tracked by issue #357 

## Verification [Optional]

Here is a screenshot with the change:
<img width="1728" alt="Screenshot 2023-12-16 at 12 31 27 PM" src="https://github.com/phlask/phlask-map/assets/8053203/f4aa47d4-2a2f-4ea0-9bbf-71935d4b7fb8">

Related Issue: #357 

