### PR TITLE
Fixes #369 - Removed "Add Resources" button from the sidebar

### DIFF
--- a/src/components/SideBar/SideBar.js
+++ b/src/components/SideBar/SideBar.js
@@ -86,17 +86,6 @@ export default function SideBar({ open, setOpenResourceModal, showControls }) {
           </ListItemButton>
         </SidebarLink>
 
-        <SidebarLink to="share" onClick={handleClose}>
-          <ListItemButton>
-            <ListItemIcon sx={{ marginLeft: '-4px' }}>
-              <PlusCircleIcon />
-            </ListItemIcon>
-            <ListItemText sx={{ marginTop: '-4px' }}>
-              Add Resources
-            </ListItemText>
-          </ListItemButton>
-        </SidebarLink>
-
         <SidebarLink to="contribute" onClick={handleClose}>
           <ListItemButton>
             <ListItemIcon sx={{ marginLeft: '-3px' }}>


### PR DESCRIPTION
# Pull Request

## Change Summary
Removed the "Add Resources" button from the sidebar for phone-sized screens.

## Change Reason
The "Add Resources" button in the sidebar was redundant as it already exists in the modal below. This change aims to improve the user experience by eliminating unnecessary duplication and streamlining the interface.

## Verification [Optional]



Related Issue: #369

