### PR TITLE
Remove Info Icon from Desktop #411

### DIFF
--- a/src/components/ReactGoogleMaps/ReactGoogleMaps.js
+++ b/src/components/ReactGoogleMaps/ReactGoogleMaps.js
@@ -522,7 +522,7 @@ export class ReactGoogleMaps extends Component {
               search={location => this.searchForLocation(location)}
             />
             <TutorialModal
-              showButton={isMobile ? !this.state.isSearchBarShown : true}
+              showButton={isMobile ? !this.state.isSearchBarShown : false}
             />
           </Stack>
           <ChooseResource />


### PR DESCRIPTION
# Pull Request

## Change Summary

Bug

## Change Reason

An information icon appears in the bottom left corner of map on desktop. Clicking on icon opens the tutorial modal. This should not be there and should be removed.



Related Issue: #<Github Issue Number (411)>

