### PR TITLE
Hotfix for showing the resources menu on mobile

### DIFF
--- a/src/actions/actions.js
+++ b/src/actions/actions.js
@@ -186,11 +186,11 @@ export const togglePhlaskType = phlaskType => ({
   mode: phlaskType
 });
 
-// export const TOGGLE_RESOURCE_MENU = 'TOGGLE_RESOURCE_MENU';
-// export const toggleResourceMenu = isShown => ({
-//   type: TOGGLE_RESOURCE_MENU,
-//   isShown
-// });
+export const TOGGLE_RESOURCE_MENU = 'TOGGLE_RESOURCE_MENU';
+export const toggleResourceMenu = isShown => ({
+  type: TOGGLE_RESOURCE_MENU,
+  isShown
+});
 
 export const CHANGE_PHLASK_TYPE = 'CHANGE_PHLASK_TYPE';
 export const changePhlaskType = phlaskType => ({

--- a/src/components/ResourceMenu/ListItemEntry.js
+++ b/src/components/ResourceMenu/ListItemEntry.js
@@ -14,10 +14,10 @@ const ListItemEntry = ({ resourceType, icon, actionLabel }) => {
   const isResourceMenuShown = useSelector(isResourceMenuShownSelector);
 
   const toggleResourceMenu = () => {
-    // dispatch({
-    //   type: Action.TOGGLE_RESOURCE_MENU,
-    //   isShown: isResourceMenuShown
-    // });
+    dispatch({
+      type: Action.TOGGLE_RESOURCE_MENU,
+      isShown: isResourceMenuShown
+    });
   };
 
   function handleGA(type) {

--- a/src/components/ResourceMenu/ResourceMenu.js
+++ b/src/components/ResourceMenu/ResourceMenu.js
@@ -40,10 +40,10 @@ const ResourceMenu = () => {
   const isResourceMenuShown = useSelector(isResourceMenuShownSelector);
 
   const toggleResourceMenu = () => {
-    // dispatch({
-    //   type: Action.TOGGLE_RESOURCE_MENU,
-    //   isShown: isResourceMenuShown
-    // });
+    dispatch({
+      type: Action.TOGGLE_RESOURCE_MENU,
+      isShown: isResourceMenuShown
+    });
   };
 
   return (

--- a/src/components/Toolbar/Toolbar.js
+++ b/src/components/Toolbar/Toolbar.js
@@ -17,7 +17,8 @@ import {
   setToolbarModal,
   setUserLocation,
   toggleInfoWindow,
-  togglePhlaskType
+  togglePhlaskType,
+  toggleResourceMenu
 } from '../../actions/actions';
 import styles from './Toolbar.module.scss';
 
@@ -54,7 +55,7 @@ function distance(lat1, lon1, lat2, lon2) {
     (Math.cos(lat1 * p) *
       Math.cos(lat2 * p) *
       (1 - Math.cos((lon2 - lon1) * p))) /
-      2;
+    2;
   return 12742 * Math.asin(Math.sqrt(a));
 }
 
@@ -376,6 +377,9 @@ function Toolbar(props) {
             <NavigationItem
               label={<Typography fontSize="small">Resources</Typography>}
               icon={<ResourceIcon className={styles.resourceButton} />}
+              onClick={() =>
+                props.toggleResourceMenu(props.isResourceMenuShown)
+              }
             />
             <ResourceMenu />
             <NavigationItem
@@ -417,7 +421,8 @@ const mapStateToProps = state => ({
   allBathroomTaps: state.allBathroomTaps,
   allForagingTaps: state.allForagingTaps,
   userLocation: state.userLocation,
-  toolbarModal: state.toolbarModal
+  toolbarModal: state.toolbarModal,
+  isResourceMenuShown: state.isResourceMenuShown
 });
 
 const mapDispatchToProps = {
@@ -435,7 +440,8 @@ const mapDispatchToProps = {
   setSelectedPlace,
   toggleInfoWindow,
   setMapCenter,
-  setUserLocation
+  setUserLocation,
+  toggleResourceMenu
 };
 
 export default connect(mapStateToProps, mapDispatchToProps)(Toolbar);

--- a/src/reducers/filterMarkers.js
+++ b/src/reducers/filterMarkers.js
@@ -33,7 +33,8 @@ const initialState = {
   allForagingTaps: [],
   selectedPlace: {},
   toolbarModal: actions.TOOLBAR_MODAL_NONE,
-  phlaskType: actions.PHLASK_TYPE_WATER
+  phlaskType: actions.PHLASK_TYPE_WATER,
+  isResourceMenuShown: false
 };
 
 export default (state = initialState, act) => {
@@ -114,25 +115,25 @@ export default (state = initialState, act) => {
       return typeof act.selectedPlace === 'object'
         ? { ...state, selectedPlace: act.selectedPlace }
         : {
-            ...state,
-            selectedPlace:
-              state.phlaskType === actions.PHLASK_TYPE_WATER
-                ? state.allTaps[act.selectedPlace]
-                : state.allFoodOrgs[act.selectedPlace],
-            showingInfoWindow: true
-          };
+          ...state,
+          selectedPlace:
+            state.phlaskType === actions.PHLASK_TYPE_WATER
+              ? state.allTaps[act.selectedPlace]
+              : state.allFoodOrgs[act.selectedPlace],
+          showingInfoWindow: true
+        };
 
     case actions.TOGGLE_INFO_WINDOW:
       // console.log('Info Window Class: ' + state.infoWindowClass);
 
       return act.isShown
         ? {
-            ...state,
-            showingInfoWindow: act.isShown,
-            infoWindowClass: isMobile
-              ? 'info-window-in'
-              : 'info-window-in-desktop'
-          }
+          ...state,
+          showingInfoWindow: act.isShown,
+          infoWindowClass: isMobile
+            ? 'info-window-in'
+            : 'info-window-in-desktop'
+        }
         : { ...state, showingInfoWindow: act.isShown };
 
     case actions.TOGGLE_INFO_WINDOW_CLASS:
@@ -146,8 +147,8 @@ export default (state = initialState, act) => {
             ? 'info-window-in'
             : 'info-window-out'
           : act.isShown
-          ? 'info-window-in-desktop'
-          : 'info-window-out-desktop'
+            ? 'info-window-in-desktop'
+            : 'info-window-out-desktop'
       };
 
     case actions.TOGGLE_INFO_EXPANDED:
@@ -228,6 +229,9 @@ export default (state = initialState, act) => {
 
     case actions.CHANGE_PHLASK_TYPE:
       return { ...state, phlaskType: act.phlaskType };
+
+    case actions.TOGGLE_RESOURCE_MENU:
+      return { ...state, isResourceMenuShown: !act.isShown };
 
     default:
       return state;


### PR DESCRIPTION
# Pull Request

## Change Summary

Provides a hotfix to bring back the resources menu when clicked on mobile, which was a regression. 

The resources menu worked in commit 987992c9e0cf145e5fd13dd5595c90a9eb69aead, but stopped working in the subsequent commit, 1d4332f4cb2d3df8e9a4bd8ff1a627c95289cad1. This PR brings the relevant code back from the former. 

## Change Reason

Addresses issues #401 and #345. 

## Verification

Image showing the resources menu visible after clicking the resources button on mobile:

<img width="397" alt="Resources_Menu_Shown" src="https://github.com/phlask/phlask-map/assets/87270246/218d1ddf-66c9-4358-a19a-b2e9eb30cbdc">

Related Issues: #401, #345