### PR TITLE
Geocode Address in Form

### DIFF
--- a/src/components/AddResourceModal/AddResourceModalV2.jsx
+++ b/src/components/AddResourceModal/AddResourceModalV2.jsx
@@ -14,7 +14,7 @@ import AddBathroom from './AddBathroom/AddBathroom';
 import AddForaging from './AddForaging/AddForaging';
 import AddWaterTap from './AddWaterTap/AddWaterTap';
 import ModalWrapper from './ModalWrapper';
-import { getDatabase, ref, set, onValue } from 'firebase/database';102
+import { getDatabase, ref, set, onValue } from 'firebase/database';
 import { geocodeByAddress, getLatLng } from 'react-places-autocomplete';
 
 export default function AddResourceModalV2(props) {

--- a/src/components/AddResourceModal/AddResourceModalV2.jsx
+++ b/src/components/AddResourceModal/AddResourceModalV2.jsx
@@ -6,6 +6,7 @@ import {
   TOOLBAR_MODAL_CONTRIBUTE
 } from '../../actions/actions';
 
+import { debounce } from '../../utils/debounce';
 import ChooseResource from './ChooseResource';
 import ShareSocials from './ShareSocials';
 import AddFood from './AddFood/AddFood';
@@ -95,43 +96,29 @@ export default function AddResourceModalV2(props) {
     });
   };
 
-  const debounce = (func, delay) => {
-    let timeoutId;
-    return (...args) => {
-      if (timeoutId) {
-        clearTimeout(timeoutId);
-      }
-      timeoutId = setTimeout(() => {
-        func(...args);
-      }, delay);
-    };
-  };
-
-const debouncedGeocode = debounce(address => {
-  geocodeByAddress(address)
-    .then(results => {
-      if (results.length === 0) {
-        throw new Error('ZERO_RESULTS');
-      }
-      return getLatLng(results[0]);
-    })
-    .then(({ lat, lng }) => {
-      console.log('Successfully got latitude and longitude', { lat, lng });
-      // Update the state with the latitude and longitude
-      setValues(prevValues => ({
-        ...prevValues,
-        latitude: lat,
-        longitude: lng
-      }));
-    })
-    .catch(error => {
-      if (error.message !== 'ZERO_RESULTS') {
-        console.error('Error occurred during geocoding:', error);
-      } else {
-        console.log(`No results found for the provided address: ${address}`);
-      }
-    });
-}, 500); // 500ms debounce delay
+  // Use imported debounce to prevent the geocoding API from being called too frequently
+  const debouncedGeocode = debounce(address => {
+    geocodeByAddress(address)
+      .then(results => {
+        if (results.length === 0) {
+          throw new Error('ZERO_RESULTS');
+        }
+        return getLatLng(results[0]);
+      })
+      .then(({ lat, lng }) => {
+        // Update the state with the latitude and longitude
+        setValues(prevValues => ({
+          ...prevValues,
+          latitude: lat,
+          longitude: lng
+        }));
+      })
+      .catch(error => {
+        if (error.message !== 'ZERO_RESULTS') {
+          console.error('Error occurred during geocoding:', error);
+        }
+      });
+  }, 500); // 500ms debounce delay
 
 const textFieldChangeHandler = eventOrString => {
   let newValue;

--- a/src/utils/debounce.js
+++ b/src/utils/debounce.js
@@ -1,0 +1,14 @@
+/**
+ * Debounce function to limit the rate at which a function can fire.
+ *
+ * @param {Function} func - The function to debounce.
+ * @param {number} wait - The number of milliseconds to delay.
+ * @returns {Function} A debounced version of the input function.
+ */
+export function debounce(func, wait) {
+    let timeout;
+    return function (...args) {
+        clearTimeout(timeout);
+        timeout = setTimeout(() => func.apply(this, args), wait);
+    };
+}


### PR DESCRIPTION
# Pull Request

## Change Summary

- Added getLatLng from [react-places-autocomplete](https://www.npmjs.com/package/react-places-autocomplete#geocode-by-address) 
- Updated `textFieldChangeHandler` to geocode the address (using the above library). Uses a debounce delay. 
- Added lat/lon fields to `initialState` (as null) and `newData` json (updated).

## Change Reason

- Related issue #392 addresses handling the user location and reverse geocoding. But that was the default lat/lng being passed as the resource location as well. With this PR, the user can specify an address (and its geocoded lat/lon values are passed with new data inserts) 

## Verification [Optional]

- [Video Explanation](https://drive.google.com/file/d/1zWj-tqIm6RnMqt7l6lW6KZB4domphxP6/view?usp=drive_link)

Related Issue: #392

