### PR TITLE
Use new modal in desktop view

### DIFF
--- a/src/components/SelectedTap/SelectedTap.js
+++ b/src/components/SelectedTap/SelectedTap.js
@@ -20,7 +20,7 @@ import styles from './SelectedTap.module.scss';
 import { Paper, SwipeableDrawer } from '@mui/material';
 import IconButton from '@mui/material/IconButton';
 
-import SelectedTapMobile from '../SelectedTapMobile/SelectedTapMobile';
+import SelectedTapDetails from '../SelectedTapMobile/SelectedTapDetails';
 import { withStyles } from '@mui/styles';
 import MoreHorizIcon from '@mui/icons-material/MoreHoriz';
 import IosShareIcon from '@mui/icons-material/IosShare';
@@ -224,18 +224,19 @@ class SelectedTap extends React.Component {
                 onClose={() => this.toggleInfoWindow(false)}
                 PaperProps={{ square: false }}
               >
-                <SelectedTapMobile
+                <SelectedTapDetails
                   image={tempImages.tapImg}
                   estWalkTime={this.state.walkingDuration}
                   selectedPlace={this.props.selectedPlace}
                   infoCollapse={this.state.infoCollapseMobile}
                   setInfoCollapse={this.setInfoCollapseMobile}
+                  isMobile={true}
                 >
                   <SelectedTapHours
                     infoIsExpanded={this.props.infoIsExpanded}
                     selectedPlace={this.props.selectedPlace}
                   />
-                </SelectedTapMobile>
+                </SelectedTapDetails>
               </SwipeableDrawer>
             )}
           </div>
@@ -249,158 +250,24 @@ class SelectedTap extends React.Component {
                 right: '32px',
                 top: '20px',
                 width: '708px',
-                height: '700px'
+                height: '700px',
+                borderRadius: '10px'
               }}
             >
-              {/* <DialogTitle>Dialog Title</DialogTitle> */}
-
-              <IconButton
-                aria-label="close"
-                onClick={() => {
-                  this.toggleInfoWindow(false);
-                }}
-                sx={{
-                  position: 'absolute',
-                  left: '45px',
-                  top: 20,
-                  color: '#000000'
-                }}
-                size="large"
+              <SelectedTapDetails
+                image={tempImages.tapImg}
+                estWalkTime={this.state.walkingDuration}
+                selectedPlace={this.props.selectedPlace}
+                infoCollapse={this.state.infoCollapseMobile}
+                setInfoCollapse={this.setInfoCollapseMobile}
+                isMobile={false}
+                closeModal={() => this.toggleInfoWindow(false)}
               >
-                <CloseIcon
-                  sx={{
-                    fontSize: 34
-                  }}
+                <SelectedTapHours
+                  infoIsExpanded={true}
+                  selectedPlace={this.props.selectedPlace}
                 />
-              </IconButton>
-
-              <IconButton
-                aria-label="close"
-                onClick={() => {
-                  this.toggleInfoWindow(true);
-                }}
-                sx={{
-                  float: 'right',
-                  right: '150px',
-                  top: 20,
-                  color: '#000000'
-                }}
-                // size="large"
-              >
-                <IosShareIcon
-                  sx={{
-                    fontSize: 34
-                  }}
-                />
-              </IconButton>
-
-              <IconButton
-                aria-label="close"
-                onClick={() => {
-                  this.toggleInfoWindow(true);
-                }}
-                sx={{
-                  float: 'right',
-                  top: 20,
-                  color: '#000000'
-                }}
-              >
-                <MoreHorizIcon
-                  sx={{
-                    fontSize: 34
-                  }}
-                />
-              </IconButton>
-
-              {/* Location Name */}
-              <div
-                ref={this.refContentArea}
-                className={
-                  this.props.infoIsExpanded
-                    ? styles.tapContentExpanded
-                    : styles.tapContent
-                }
-              >
-                {/* Main Image */}
-
-                <div id="tap-info-img-box-desktop">
-                  <img-alt
-                    id="tap-info-img"
-                    src={tempImages.tapImg}
-                    srcSet={
-                      tempImages.tapImg + ', ' + tempImages.tapImg2x + ' 2x'
-                    }
-                  ></img-alt>
-                </div>
-                {/* Main Image */}
-
-                <div id="tap-head-info">
-                  {/* Tap Type Icon */}
-                  <div id="tap-type-icon-container">
-                    <div id="tap-type-icon">
-                      {this.props.resourceType === WATER_RESOURCE_TYPE ? (
-                        <img
-                          className="tap-info-icon-img"
-                          src={this.props.selectedPlace?.infoIcon}
-                          alt=""
-                        ></img>
-                      ) : (
-                        this.props.selectedPlace?.infoIcon
-                      )}
-                    </div>
-                  </div>
-
-                  {/* Name & Address */}
-                  <div id="org-name-and-address-desktop">
-                    <div id="tap-organization-name" data-cy="tap-organization-name">
-                      {this.state.name}
-                    </div>
-                    {this.state.address && (
-                      <h5 id="tap-info-address">{this.state.address}</h5>
-                    )}
-                  </div>
-
-                  <SelectedTapHours
-                    infoIsExpanded={this.props.infoIsExpanded}
-                    selectedPlace={this.props.selectedPlace}
-                  />
-                </div>
-                {/* Walk Time & Info Icons  */}
-                <div className={styles.walkTime}>
-                  Estimated Walk Time: {this.state.walkingDuration} mins (
-                  {this.state.walkingDistance} mi)
-                </div>
-
-                <SelectedTapIcons place={this.props.selectedPlace} />
-
-                {/* Description */}
-                <div>
-                  <div>
-                    <div className={styles.description}>
-                      <div id="tap-info-description">
-                        {this.state.tapDescription && (
-                          <div className={styles.section}>
-                            <h3>Description</h3>
-                            <div>{this.state.tapDescription}</div>
-                          </div>
-                        )}
-                        {this.state.tapStatement && (
-                          <div className={styles.section}>
-                            <h3>Statement</h3>
-                            <div>{this.state.tapStatement}</div>
-                          </div>
-                        )}
-                        {this.state.tapNormsAndRules && (
-                          <div className={styles.section}>
-                            <h3>Norms &amp; Rules</h3>
-                            <div>{this.state.tapNormsAndRules}</div>
-                          </div>
-                        )}
-                      </div>
-                    </div>
-                  </div>
-                </div>
-              </div>
+              </SelectedTapDetails>
             </Paper>
           </div>
         )}

--- a/src/components/SelectedTapHours/SelectedTapHours.js
+++ b/src/components/SelectedTapHours/SelectedTapHours.js
@@ -79,33 +79,9 @@ const SelectedTapHours = ({ infoIsExpanded, selectedPlace }) => {
   // console.log(typeof(currentOrgHours))
   return (
     <>
-      {isMobile && (
-        <div className={styles.tapHoursMobile}>
-          <div id="tap-info-org-status">
-            <p
-              style={
-                isOpen
-                  ? { color: 'green' }
-                  : isOpen !== null
-                  ? { color: 'red' }
-                  : { color: 'orange' }
-              }
-            >
-              {isOpen ? 'Open' : isOpen !== null ? 'Closed' : 'Open times unavailable'}
-            </p>
-          </div>
-
-          {currentOrgHours && (
-            <p>
-              <span>&nbsp;-</span> <span>closes {currentOrgHours.close}</span>
-            </p>
-          )}
-        </div>
-      )}
-      {!isMobile && (
-        <div id="org-hours">
-          <div
-            id="tap-info-org-status"
+      <div className={styles.tapHoursMobile}>
+        <div id="tap-info-org-status">
+          <p
             style={
               isOpen
                 ? { color: 'green' }
@@ -114,124 +90,20 @@ const SelectedTapHours = ({ infoIsExpanded, selectedPlace }) => {
                 : { color: 'orange' }
             }
           >
-            {isOpen ? 'Open' : isOpen !== null ? 'Closed' : 'unavailable'}
-          </div>
-          {currentOrgHours && (
-            <div id="hours-area">
-              {/* Placeholder for Dropdown */}
-
-              <div
-                id="tap-info-hours-container-placeholder"
-                style={
-                  currentOrgHours !== null
-                    ? { border: '1px solid #c4c4c4' }
-                    : {}
-                }
-              >
-                <div className="tap-hours-list-item">Placeholder</div>
-              </div>
-
-              {/* Container of all visible hours elements */}
-              <div
-                id="tap-info-hours-container"
-                style={
-                  currentOrgHours !== null
-                    ? { border: '1px solid #c4c4c4' }
-                    : {}
-                }
-              >
-                {/* Placeholder for Dropdown */}
-                <div id="current-hours-placeholder">
-                  <div className="tap-hours-list-item">
-                    {currentOrgHours !== null
-                      ? currentOrgHours !== false
-                        ? `${currentOrgHours.day} ${currentOrgHours.open} - ${currentOrgHours.close}`
-                        : ''
-                      : ''}
-                  </div>
-                  {(infoIsExpanded || !isMobile) &&
-                    hoursList !== null &&
-                    currentOrgHours !== false && (
-                      <div className={styles.hoursDropdownArrowContainer}>
-                        <FontAwesomeIcon
-                          className={styles.hoursDropdownArrow}
-                          color="#999"
-                          size="2x"
-                          icon={faCaretDown}
-                        />
-                      </div>
-                    )}
-                </div>
-
-                {/* Current Day Hours */}
-                {/* Accessibility Note - This is using the Disclosure Pattern:
-              https://www.w3.org/TR/2021/NOTE-wai-aria-practices-1.2-20211129/examples/disclosure/disclosure-faq.html*/}
-                <div
-                  id="current-hours"
-                  role="button"
-                  tabIndex={0}
-                  aria-expanded="false"
-                  onKeyDown={() => {
-                    setIsHoursExpanded(true);
-                  }}
-                  onKeyUp={() => {
-                    setIsHoursExpanded(false);
-                  }}
-                  onClick={() => {
-                    if (infoIsExpanded || !isMobile) {
-                      setIsHoursExpanded(!isHoursExpanded);
-                    }
-                  }}
-                >
-                  <div className="tap-hours-list-item">
-                    {currentOrgHours !== null
-                      ? currentOrgHours !== false
-                        ? currentOrgHours.open // TODO: Update this logic so that "705 S. 5th St." shows closed on Tuesdays (or any business shows closed on current_day)
-                          ? `${currentOrgHours.day} ${currentOrgHours.open} - ${currentOrgHours.close}`
-                          : `${currentOrgHours.day} Closed`
-                        : ''
-                      : ''}
-                  </div>
-                  {(infoIsExpanded || !isMobile) &&
-                    hoursList !== null &&
-                    currentOrgHours !== false && (
-                      <div className={styles.hoursDropdownArrowContainer}>
-                        <FontAwesomeIcon
-                          className={styles.hoursDropdownArrow}
-                          color="#999"
-                          size="2x"
-                          icon={faCaretDown}
-                        />
-                      </div>
-                    )}
-                </div>
-                {/* Other Days */}
-                {isHoursExpanded && (infoIsExpanded || !isMobile) ? (
-                  <div id="other-hours-container">
-                    {hoursList !== null ? (
-                      hoursList.map((hours, index) => {
-                        if (index !== 0) {
-                          return (
-                            <div className="tap-hours-list-item" key={index}>
-                              {hours.open
-                                ? `${hours.day} ${hours.open} - ${hours.close}`
-                                : `${hours.day} Closed`}
-                            </div>
-                          );
-                        }
-                      })
-                    ) : (
-                      <div className="tap-hours-list-item">n/a</div>
-                    )}
-                  </div>
-                ) : (
-                  <div></div>
-                )}
-              </div>
-            </div>
-          )}
+            {isOpen
+              ? 'Open'
+              : isOpen !== null
+              ? 'Closed'
+              : 'Open times unavailable'}
+          </p>
         </div>
-      )}
+
+        {currentOrgHours && (
+          <p>
+            <span>&nbsp;-</span> <span>closes {currentOrgHours.close}</span>
+          </p>
+        )}
+      </div>
     </>
   );
 };

--- a/src/components/SelectedTapMobile/SelectedTapDetails.js
+++ b/src/components/SelectedTapMobile/SelectedTapDetails.js
@@ -1,26 +1,50 @@
 import { Button, Collapse, IconButton } from '@mui/material';
 import { styled } from '@mui/material/styles';
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useState } from 'react';
 import styles from './SelectedTapMobileInfo.module.scss';
+import CloseIcon from '@mui/icons-material/Close';
 
 import { ReactComponent as DirectionIcon } from '../images/ArrowElbowUpRight.svg';
 import { ReactComponent as CaretDownSvg } from '../images/CaretDown.svg';
-import { ReactComponent as ThreeDotSvg } from '../images/DotsThree.svg';
 import { ReactComponent as ExportSvg } from '../images/Export.svg';
 
 import FountainIcon from '../icons/CircleWaterIcon.svg';
+import ForagingIcon from '../icons/CircleForagingIcon.svg';
+import FoodIcon from '../icons/CircleFoodIcon.svg';
+import BathroomIcon from '../icons/CircleBathroomIcon.svg';
 
-function SelectedTapMobile(props) {
+import {
+  WATER_RESOURCE_TYPE,
+  FOOD_RESOURCE_TYPE,
+  FORAGE_RESOURCE_TYPE,
+  BATHROOM_RESOURCE_TYPE
+} from '../../types/ResourceEntry';
+
+function SelectedTapDetails(props) {
   const [pointerPositionY, setPointerPositionY] = useState(0);
 
-  const { image, estWalkTime, infoCollapse, setInfoCollapse } = props;
+  const {
+    image,
+    estWalkTime,
+    infoCollapse,
+    setInfoCollapse,
+    isMobile,
+    closeModal
+  } = props;
 
   /**
    * @type {ResourceEntry}
    */
   const resource = props.selectedPlace;
 
-  const icon = FountainIcon; // TODO: Add other icons
+  const icon =
+    resource.resource_type === WATER_RESOURCE_TYPE
+      ? FountainIcon
+      : resource.resource_type === FORAGE_RESOURCE_TYPE
+      ? ForagingIcon
+      : resource.resource_type === FOOD_RESOURCE_TYPE
+      ? FoodIcon
+      : BathroomIcon;
 
   // From resource info, collect all the tags.
   const tags = [
@@ -60,6 +84,9 @@ function SelectedTapMobile(props) {
 
   // Expanding and Minimizing the Modal
   const detectSwipe = e => {
+    if (!isMobile) {
+      return;
+    }
     setPointerPositionY(e.nativeEvent.offsetY);
 
     if (!infoCollapse && e.nativeEvent.offsetY < 0) {
@@ -68,6 +95,9 @@ function SelectedTapMobile(props) {
   };
 
   const minimizeModal = () => {
+    if (!isMobile) {
+      return;
+    }
     setInfoCollapse(false);
   };
 
@@ -82,17 +112,14 @@ function SelectedTapMobile(props) {
 
   return (
     <div className={styles.halfInfo} onPointerMove={detectSwipe}>
-      {!infoCollapse ? (
+      {isMobile && !infoCollapse ? (
         <button className={styles.swipeIcon}></button>
       ) : (
         <div className={styles.expandedToolBar}>
-          <IconButton color="primary" aria-label="" onClick={minimizeModal}>
-            <CaretDownSvg />
-          </IconButton>
           <div>
             <IconButton
               color="primary"
-              aria-label="export"
+              aria-label="share"
               component="label"
               onClick={toggleNativeShare}
             >
@@ -103,6 +130,30 @@ function SelectedTapMobile(props) {
             {/*  <ThreeDotSvg />*/}
             {/*</IconButton>*/}
           </div>
+          {/* On mobile, show the minimize button. On desktop, show the close button */}
+          {isMobile && (
+            <IconButton color="primary" aria-label="" onClick={minimizeModal}>
+              <CaretDownSvg />
+            </IconButton>
+          )}
+          {!isMobile && (
+            <IconButton
+              color="primary"
+              aria-label="close"
+              onClick={() => {
+                closeModal();
+              }}
+              sx={{
+                position: 'absolute',
+                right: '20px',
+                top: 5,
+                color: 'black'
+              }}
+              size="large"
+            >
+              <CloseIcon fontSize="18px" />
+            </IconButton>
+          )}
           {/* Currently the three dot button does nothing */}
         </div>
       )}
@@ -114,7 +165,9 @@ function SelectedTapMobile(props) {
           style={{ width: '52px' }}
         />
         <div className={styles.mainHalfInfoText}>
-          <h2 className={styles.organization} data-cy="tap-organization-name">{resource.name}</h2>
+          <h2 className={styles.organization} data-cy="tap-organization-name">
+            {resource.name}
+          </h2>
           <p>{resource.address}</p>
           {props.children}
           <Button
@@ -152,7 +205,7 @@ function SelectedTapMobile(props) {
         {tags.length > 0 && <hr className={styles.botDivider} />}
       </div>
 
-      <Collapse in={infoCollapse} timeout="auto" unmountOnExit>
+      <Collapse in={infoCollapse || !isMobile} timeout="auto" unmountOnExit>
         <div className={styles.halfInfoExpand}>
           <div className={styles.details}>
             <h3>Description</h3>
@@ -176,4 +229,4 @@ function SelectedTapMobile(props) {
   );
 }
 
-export default SelectedTapMobile;
+export default SelectedTapDetails;


### PR DESCRIPTION
This PR does two things:

1. Uses the existing mobile detailed resource view as part of the desktop view now.
2. Fixes the icons displayed in the modal

<img width="1668" alt="Screenshot 2024-06-22 at 11 29 38 AM" src="https://github.com/phlask/phlask-map/assets/8053203/b6b137f9-4044-4ea5-b9dd-2c8cd6e3ba4a">
<img width="1669" alt="Screenshot 2024-06-22 at 11 34 23 AM" src="https://github.com/phlask/phlask-map/assets/8053203/14527c24-df94-44d7-9f79-14bc993ffcbe">
