### PR TITLE
feat: make mobile head show a bottom drawer

### DIFF
--- a/src/components/DesktopHead/DesktopHead.jsx
+++ b/src/components/DesktopHead/DesktopHead.jsx
@@ -67,7 +67,7 @@ export const DesktopHead = props => {
             </Button>
           </Box>
           <Collapse
-            in={shownPage}
+            in={Boolean(shownPage)}
             timeout="auto"
             onEntered={() => {
               if (shownPage) {
@@ -106,7 +106,7 @@ export const DesktopHead = props => {
             </Box>
           </Collapse>
           <Collapse
-            in={shownPage}
+            in={Boolean(shownPage)}
             timeout="auto"
             onEntered={() => {
               if (shownPage) {
@@ -121,7 +121,11 @@ export const DesktopHead = props => {
             ></Box>
           </Collapse>
         </Box>
-        <Collapse orientation="horizontal" in={shownPage} timeout="auto">
+        <Collapse
+          orientation="horizontal"
+          in={Boolean(shownPage)}
+          timeout="auto"
+        >
           <Box
             sx={{
               width: 'min(900px, calc(100vw - 25px - 25px - 310px))',

--- a/src/components/DesktopHead/DesktopHead.jsx
+++ b/src/components/DesktopHead/DesktopHead.jsx
@@ -17,7 +17,6 @@ export const DesktopHead = props => {
     menuExpand,
     setShowMapControls,
     showMapControls,
-    pageExpand,
     verticalAnimFinished1,
     verticalAnimFinished2,
     setVerticalAnimFinished1,
@@ -68,10 +67,10 @@ export const DesktopHead = props => {
             </Button>
           </Box>
           <Collapse
-            in={pageExpand}
+            in={shownPage}
             timeout="auto"
             onEntered={() => {
-              if (pageExpand) {
+              if (shownPage) {
                 setVerticalAnimFinished1(true);
               }
             }}
@@ -107,10 +106,10 @@ export const DesktopHead = props => {
             </Box>
           </Collapse>
           <Collapse
-            in={pageExpand}
+            in={shownPage}
             timeout="auto"
             onEntered={() => {
-              if (pageExpand) {
+              if (shownPage) {
                 setVerticalAnimFinished2(true);
               }
             }}
@@ -122,7 +121,7 @@ export const DesktopHead = props => {
             ></Box>
           </Collapse>
         </Box>
-        <Collapse orientation="horizontal" in={pageExpand} timeout="auto">
+        <Collapse orientation="horizontal" in={shownPage} timeout="auto">
           <Box
             sx={{
               width: 'min(900px, calc(100vw - 25px - 25px - 310px))',

--- a/src/components/Head/Head.js
+++ b/src/components/Head/Head.js
@@ -9,26 +9,9 @@ import useIsMobile from 'hooks/useIsMobile.js';
 export default function Head(props) {
   const isMobile = useIsMobile();
 
-  let page = null;
-  switch (HeaderProvider.shownPage) {
-    case 'about':
-      page = <About />;
-      break;
-    case 'join':
-      page = <Join />;
-      break;
-    case 'contact':
-      page = <Contact />;
-      break;
-    default:
-      break;
-  }
-
   return (
-    <>
-      <HeaderProvider>
-        {isMobile ? <MobileHead /> : <DesktopHead />}
-      </HeaderProvider>
-    </>
+    <HeaderProvider>
+      {isMobile ? <MobileHead /> : <DesktopHead />}
+    </HeaderProvider>
   );
 }

--- a/src/components/MobileHead/MobileHead.jsx
+++ b/src/components/MobileHead/MobileHead.jsx
@@ -1,5 +1,12 @@
 import React from 'react';
-import { Button, Collapse, IconButton, Box, Paper } from '@mui/material';
+import {
+  Button,
+  Collapse,
+  IconButton,
+  Box,
+  Paper,
+  SwipeableDrawer
+} from '@mui/material';
 import CloseIcon from '../../components/icons/CloseIcon';
 import DropLink from '../../components/Buttons/DropLink';
 import { HeaderContext } from '../../contexts/HeaderContext';
@@ -26,7 +33,6 @@ function MobileHead() {
     menuClicked,
     toggleMenuExpand,
     menuExpand,
-    pageExpand,
     verticalAnimFinished1,
     verticalAnimFinished2,
     setVerticalAnimFinished1,
@@ -35,115 +41,126 @@ function MobileHead() {
 
   const toolbarModal = useSelector(state => state.filterMarkers.toolbarModal);
   return (
-    <Box
-      sx={{
-        backgroundColor: 'transparent',
-        position: 'absolute',
-        maxWidth: '100%',
-        zIndex: '9',
-        width: '100%'
-      }}
-    >
-      <Paper
+    <>
+      <Box
         sx={{
-          display: 'flex',
-          padding: '0 0 0 0'
+          backgroundColor: 'transparent',
+          position: 'absolute',
+          maxWidth: '100%',
+          zIndex: '9',
+          width: '100%'
         }}
       >
-        <Box sx={{ height: 'fit-content', width: '100%' }}>
-          <Box
-            sx={{
-              display: 'flex',
-              width: '100%',
-              justifyContent: 'space-between'
-            }}
-          >
-            <IconButton
-              sx={{
-                margin: '15px'
-              }}
-              onClick={toggleMenuExpand}
-              data-cy="head-sidebar-button"
-            >
-              <CloseIcon close={menuExpand} />
-            </IconButton>
-            <Button
-              href="/"
-              sx={{
-                margin: '15px'
-              }}
-              onClick={() => setShowMapControls(true)}
-            >
-              <PhlaskIcon
-                sx={{
-                  position: 'relative',
-                  top: '-10px'
-                }}
-              />
-            </Button>
-            <Box sx={{ display: 'flex', alignItems: 'center' }}>
-              <IconButton
-                onClick={() => {
-                  dispatch(
-                    setToolbarModal(
-                      toolbarModal !== TOOLBAR_MODAL_SEARCH
-                        ? TOOLBAR_MODAL_SEARCH
-                        : TOOLBAR_MODAL_NONE
-                    )
-                  );
-                }}
-              >
-                <SearchIcon />
-              </IconButton>
-              <IconButton
-                onClick={() => {
-                  if (toolbarModal != TOOLBAR_MODAL_FILTER) {
-                    dispatch(
-                      setToolbarModal({
-                        toolbarModal: TOOLBAR_MODAL_FILTER
-                      })
-                    );
-                  } else {
-                    dispatch(
-                      setToolbarModal({ toolbarModal: TOOLBAR_MODAL_NONE })
-                    );
-                  }
-                }}
-              >
-                <FilterIcon />
-              </IconButton>
-            </Box>
-          </Box>
-          <Collapse in={menuExpand} timeout="auto">
+        <Paper
+          sx={{
+            display: 'flex',
+            padding: '0 0 0 0'
+          }}
+        >
+          <Box sx={{ height: 'fit-content', width: '100%' }}>
             <Box
               sx={{
                 display: 'flex',
-                flexDirection: 'column'
+                width: '100%',
+                justifyContent: 'space-between'
               }}
             >
-              <DropLink
-                onClick={() => menuClicked('about')}
-                startIcon={<PhlaskNoTextIcon />}
+              <IconButton
+                sx={{
+                  margin: '15px'
+                }}
+                onClick={toggleMenuExpand}
+                data-cy="head-sidebar-button"
               >
-                About Phlask
-              </DropLink>
-              <DropLink
-                onClick={() => menuClicked('join')}
-                startIcon={<UsersIcon />}
+                <CloseIcon close={menuExpand} />
+              </IconButton>
+              <Button
+                href="/"
+                sx={{
+                  margin: '15px'
+                }}
+                onClick={() => setShowMapControls(true)}
               >
-                Join the team
-              </DropLink>
-              <DropLink
-                onClick={() => menuClicked('contact')}
-                startIcon={<IDIcon />}
-              >
-                Contact
-              </DropLink>
+                <PhlaskIcon
+                  sx={{
+                    position: 'relative',
+                    top: '-10px'
+                  }}
+                />
+              </Button>
+              <Box sx={{ display: 'flex', alignItems: 'center' }}>
+                <IconButton
+                  onClick={() => {
+                    dispatch(
+                      setToolbarModal(
+                        toolbarModal !== TOOLBAR_MODAL_SEARCH
+                          ? TOOLBAR_MODAL_SEARCH
+                          : TOOLBAR_MODAL_NONE
+                      )
+                    );
+                  }}
+                >
+                  <SearchIcon />
+                </IconButton>
+                <IconButton
+                  onClick={() => {
+                    if (toolbarModal != TOOLBAR_MODAL_FILTER) {
+                      dispatch(
+                        setToolbarModal({
+                          toolbarModal: TOOLBAR_MODAL_FILTER
+                        })
+                      );
+                    } else {
+                      dispatch(
+                        setToolbarModal({ toolbarModal: TOOLBAR_MODAL_NONE })
+                      );
+                    }
+                  }}
+                >
+                  <FilterIcon />
+                </IconButton>
+              </Box>
             </Box>
-          </Collapse>
-        </Box>
-      </Paper>
-    </Box>
+            <Collapse in={menuExpand} timeout="auto">
+              <Box
+                sx={{
+                  display: 'flex',
+                  flexDirection: 'column'
+                }}
+              >
+                <DropLink
+                  onClick={() => menuClicked('about')}
+                  startIcon={<PhlaskNoTextIcon />}
+                >
+                  About Phlask
+                </DropLink>
+                <DropLink
+                  onClick={() => menuClicked('join')}
+                  startIcon={<UsersIcon />}
+                >
+                  Join the team
+                </DropLink>
+                <DropLink
+                  onClick={() => menuClicked('contact')}
+                  startIcon={<IDIcon />}
+                >
+                  Contact
+                </DropLink>
+              </Box>
+            </Collapse>
+          </Box>
+        </Paper>
+      </Box>
+
+      <SwipeableDrawer
+        anchor="bottom"
+        open={Boolean(shownPage)}
+        onOpen={() => {}}
+        onClose={() => menuClicked(shownPage)}
+      >
+        <Box sx={theme => ({ padding: theme.spacing(1) })}>{shownPage}</Box>
+      </SwipeableDrawer>
+    </>
   );
 }
 

--- a/src/components/MobileHead/MobileHead.jsx
+++ b/src/components/MobileHead/MobileHead.jsx
@@ -1,12 +1,11 @@
 import React from 'react';
-import {
-  Button,
-  Collapse,
-  IconButton,
-  Box,
-  Paper,
-  SwipeableDrawer
-} from '@mui/material';
+
+import Button from '@mui/material/Button';
+import Collapse from '@mui/material/Collapse';
+import IconButton from '@mui/material/IconButton';
+import Box from '@mui/material/Box';
+import Paper from '@mui/material/Paper';
+import SwipeableDrawer from '@mui/material/SwipeableDrawer';
 import CloseIcon from '../../components/icons/CloseIcon';
 import DropLink from '../../components/Buttons/DropLink';
 import { HeaderContext } from '../../contexts/HeaderContext';

--- a/src/components/MobileHead/MobileHead.jsx
+++ b/src/components/MobileHead/MobileHead.jsx
@@ -6,6 +6,7 @@ import IconButton from '@mui/material/IconButton';
 import Box from '@mui/material/Box';
 import Paper from '@mui/material/Paper';
 import SwipeableDrawer from '@mui/material/SwipeableDrawer';
+import noop from 'utils/noop';
 import CloseIcon from '../../components/icons/CloseIcon';
 import DropLink from '../../components/Buttons/DropLink';
 import { HeaderContext } from '../../contexts/HeaderContext';
@@ -154,7 +155,7 @@ function MobileHead() {
       <SwipeableDrawer
         anchor="bottom"
         open={Boolean(shownPage)}
-        onOpen={() => {}}
+        onOpen={noop}
         onClose={() => menuClicked(shownPage)}
       >
         <Box sx={theme => ({ padding: theme.spacing(1) })}>{shownPage}</Box>

--- a/src/contexts/HeaderContext.js
+++ b/src/contexts/HeaderContext.js
@@ -3,6 +3,7 @@ import Contact from 'components/Pages/Contact';
 import Join from 'components/Pages/Join';
 import { createContext, useCallback, useEffect, useState } from 'react';
 import { useSelector } from 'react-redux';
+import useIsMobile from 'hooks/useIsMobile';
 
 const HeaderContext = createContext({});
 
@@ -13,12 +14,13 @@ const HeaderProvider = ({ children }) => {
   const [sidebarOpen, setSidebarOpen] = useState(false);
   const [showMapControls, setShowMapControls] = useState(false);
   const [menuExpand, setMenuExpand] = useState(false);
-  const [pageExpand, setPageExpand] = useState(false);
+
   const [verticalAnimFinished1, setVerticalAnimFinished1] = useState(false);
   const [verticalAnimFinished2, setVerticalAnimFinished2] = useState(false);
   const [shownPage, setShownPage] = useState(null);
   const isSearchShown = useSelector(state => state.filterMarkers.isSearchShown);
   const isFilterShown = useSelector(state => state.filterMarkers.isFilterShown);
+  const isMobile = useIsMobile();
 
   // Define any functions or values you want to expose to consumers of the context
   const open = Boolean(anchorEl);
@@ -26,7 +28,6 @@ const HeaderProvider = ({ children }) => {
     if (menuExpand) {
       setVerticalAnimFinished1(false);
       setVerticalAnimFinished2(false);
-      setPageExpand(false);
       setShownPage(null);
     }
     setMenuExpand(!menuExpand);
@@ -40,10 +41,8 @@ const HeaderProvider = ({ children }) => {
     if (page == shownPage) {
       setVerticalAnimFinished1(false);
       setVerticalAnimFinished2(false);
-      setPageExpand(false);
       setShownPage(null);
     } else {
-      setPageExpand(true);
       switch (page) {
         case 'about':
           page = <About />;
@@ -56,6 +55,9 @@ const HeaderProvider = ({ children }) => {
           break;
         default:
           break;
+      }
+      if (isMobile) {
+        setMenuExpand(false);
       }
       setShownPage(page);
     }
@@ -84,8 +86,6 @@ const HeaderProvider = ({ children }) => {
     setShowMapControls,
     menuExpand,
     setMenuExpand,
-    pageExpand,
-    setPageExpand,
     verticalAnimFinished1,
     setVerticalAnimFinished1,
     verticalAnimFinished2,


### PR DESCRIPTION
# Pull Request

## Change Summary

Added the mobile bottom drawer to display all the different PHLask screens (About, Contact, Join The Team)

## Change Reason

We would like to have a responsive app

## Verification


https://github.com/user-attachments/assets/c4953fba-7e37-49ce-b90a-5dbd1ab340ec



Related Issue: #372 , #373 , #374 

