### PR TITLE
Fix map snapback by cleaning up hooks

### DIFF
--- a/src/components/ReactGoogleMaps/ReactGoogleMaps.js
+++ b/src/components/ReactGoogleMaps/ReactGoogleMaps.js
@@ -162,8 +162,8 @@ export const ReactGoogleMaps = ({ google }) => {
   );
   const toolbarModal = useSelector(state => state.filterMarkers.toolbarModal);
 
-  const [currentLat, setCurrentLat] = useState(mapCenter.lat);
-  const [currentLon, setCurrentLon] = useState(mapCenter.lng);
+  const [currentLat, setCurrentLat] = useState(CITY_HALL_COORDINATES.latitude);
+  const [currentLon, setCurrentLon] = useState(CITY_HALL_COORDINATES.longitude);
   const [zoom, setZoom] = useState(16);
   const [searchedTap, setSearchedTap] = useState(null);
   const [map, setMap] = useState(null);
@@ -180,40 +180,6 @@ export const ReactGoogleMaps = ({ google }) => {
     }
   }, [allResources.length, dispatch]);
 
-  useEffect(() => {
-    const setDefaultLocation = () => {
-      setCurrentLat(parseFloat(CITY_HALL_COORDINATES.latitude));
-      setCurrentLon(parseFloat(CITY_HALL_COORDINATES.longitude));
-    };
-    getCoordinates()
-      .then(position => {
-        if (
-          Number.isNaN(position.coords.latitude) ||
-          Number.isNaN(position.coords.longitude)
-        ) {
-          setDefaultLocation();
-        } else {
-          dispatch(
-            setMapCenter({
-              lat: position.coords.latitude,
-              lng: position.coords.longitude
-            })
-          );
-          dispatch(
-            setUserLocation({
-              lat: position.coords.latitude,
-              lng: position.coords.longitude
-            })
-          );
-          setCurrentLat(position.coords.latitude);
-          setCurrentLon(position.coords.longitude);
-        }
-      })
-      .catch(() => {
-        setDefaultLocation();
-      });
-  }, [dispatch]);
-
   //toggle window goes here
   const onMarkerClick = (resource, markerProps) => {
     dispatch(
@@ -223,7 +189,10 @@ export const ReactGoogleMaps = ({ google }) => {
       })
     );
     dispatch(setSelectedPlace(resource));
+    setCurrentLat(resource.latitude);
+    setCurrentLon(resource.longitude);
     markerProps.map.panTo({ lat: resource.latitude, lng: resource.longitude });
+
   };
 
   const onReady = (_, map) => {
@@ -290,10 +259,6 @@ export const ReactGoogleMaps = ({ google }) => {
             rotateControl={false}
             fullscreenControl={false}
             onReady={onReady}
-            initialCenter={{
-              lat: currentLat,
-              lng: currentLon
-            }}
             center={{
               lat: currentLat,
               lng: currentLon

--- a/src/components/ReactGoogleMaps/ReactGoogleMaps.js
+++ b/src/components/ReactGoogleMaps/ReactGoogleMaps.js
@@ -180,6 +180,20 @@ export const ReactGoogleMaps = ({ google }) => {
     }
   }, [allResources.length, dispatch]);
 
+  useEffect(() => {
+    const fetchCoordinates = async () => {
+      try {
+        const position = await getCoordinates();
+        setCurrentLat(position.coords.latitude);
+        setCurrentLon(position.coords.longitude);
+      } catch (error) {
+        console.error("Error obtaining geolocation. Default coordinates will be used.");
+      }
+    };
+
+    fetchCoordinates();
+  }, []);
+  
   //toggle window goes here
   const onMarkerClick = (resource, markerProps) => {
     dispatch(

--- a/src/components/ReactGoogleMaps/ReactGoogleMaps.js
+++ b/src/components/ReactGoogleMaps/ReactGoogleMaps.js
@@ -187,7 +187,7 @@ export const ReactGoogleMaps = ({ google }) => {
         setCurrentLat(position.coords.latitude);
         setCurrentLon(position.coords.longitude);
       } catch (error) {
-        console.error("Error obtaining geolocation. Default coordinates will be used.");
+        // Do nothing
       }
     };
 


### PR DESCRIPTION
# Pull Request

## Change Summary

Fixes the map snapping back to City Hall when browsing resources. Map will now follow user, including in the search feature.

## Change Reason

Map snapping back to City Hall marks for a poor user experience when trying to browse resources on the map. It also conflicts with the panning behavior of the search functionality.

## Verification [Optional]

[phlask-500-480p.mov.zip](https://github.com/user-attachments/files/16355713/phlask-500-480p.mov.zip)


No new console errors:
<img width="766" alt="Screen Shot 2024-07-23 at 8 41 04 PM" src="https://github.com/user-attachments/assets/a79c53fc-1559-45eb-ac20-14517d96d981">

Fixes #500 

