### PR TITLE
Set Phlask DB dynamically

### DIFF
--- a/.github/workflows/betasite.yml
+++ b/.github/workflows/betasite.yml
@@ -6,7 +6,7 @@ on:
       - develop
 env:
   AWS_DEFAULT_REGION: us-east-2
-  REACT_APP_DB_URL: https://phlask-prod.firebaseio.com
+  REACT_APP_DB_URL: https://phlask-beta.firebaseio.com
 permissions:
   id-token: write   # This is required for requesting the JWT
   contents: read    # This is required for actions/checkout

--- a/.github/workflows/betasite.yml
+++ b/.github/workflows/betasite.yml
@@ -6,6 +6,7 @@ on:
       - develop
 env:
   AWS_DEFAULT_REGION: us-east-2
+  REACT_APP_DB_URL: https://phlask-prod.firebaseio.com
 permissions:
   id-token: write   # This is required for requesting the JWT
   contents: read    # This is required for actions/checkout

--- a/src/components/AddResourceModal/utils.js
+++ b/src/components/AddResourceModal/utils.js
@@ -1,47 +1,9 @@
-import { initializeApp } from 'firebase/app';
-
-export const connectToFirebase = (hostname, resourceType) => {
-  // TODO -- OLD PROD CONFIG -- DOUBLECHECK IF THIS IS NEEDED
-  // const prodConfig = {
-  //   apiKey: "AIzaSyA2E1tiV34Ou6CJU_wzlJtXxwATJXxi6K8",
-  //   authDomain: "phlask-web-map-new-taps.firebaseapp.com",
-  //   databaseURL: `https://phlask-web-map-new-taps.firebaseio.com`,
-  //   projectId: "phlask-web-map-new-taps",
-  //   storageBucket: "phlask-web-map-new-taps.appspot.com",
-  //   messagingSenderId: "673087230724",
-  //   appId: "1:673087230724:web:2545788342843cccdcf651"
-  // };
-
-  let environment;
-
-  if (hostname === 'phlask.me') {
-    environment = 'prod';
-  } else if (hostname === 'beta.phlask.me') {
-    environment = 'beta';
-  } else {
-    environment = 'test';
-  }
-
-  const firebaseConfig = {
-    apiKey: 'AIzaSyABw5Fg78SgvedyHr8tl-tPjcn5iFotB6I',
-    authDomain: 'phlask-web-map.firebaseapp.com',
-    databaseURL: `https://phlask-web-map-${environment}-${resourceType}-verify.firebaseio.com`,
-    projectId: 'phlask-web-map-new-taps',
-    storageBucket: 'phlask-web-map.appspot.com',
-    messagingSenderId: '428394983826',
-    appId: '1:428394983826:web:b81abdcfd5af5401e0514b'
-  };
-
-  // return firebase.initializeApp(firebaseConfig, "new");
-  return initializeApp(firebaseConfig, 'new');
-};
-
 export const WEBSITE_REGEX = new RegExp(
   '^([a-zA-Z]+:\\/\\/)?' + // protocol (optional)
-    '((([a-z\\d]([a-z\\d-]*[a-z\\d])*)\\.)+[a-z]{2,}|' + // domain name
-    '((\\d{1,3}\\.){3}\\d{1,3}))' + // OR IP (v4) address
-    '(\\:\\d+)?(\\/[-a-z\\d%_.~+]*)*' + // port and path
-    '(\\?[;&a-z\\d%_.~+=-]*)?' + // query string
-    '(\\#[-a-z\\d_]*)?$', // fragment locator
+  '((([a-z\\d]([a-z\\d-]*[a-z\\d])*)\\.)+[a-z]{2,}|' + // domain name
+  '((\\d{1,3}\\.){3}\\d{1,3}))' + // OR IP (v4) address
+  '(\\:\\d+)?(\\/[-a-z\\d%_.~+]*)*' + // port and path
+  '(\\?[;&a-z\\d%_.~+=-]*)?' + // query string
+  '(\\#[-a-z\\d_]*)?$', // fragment locator
   'i'
 );

--- a/src/firebase/firebaseConfig.js
+++ b/src/firebase/firebaseConfig.js
@@ -1,16 +1,21 @@
-export const contributorsConfig = {
+// Sets the Phlask Database URL to use the test instance unless overriden
+// This environment variable will also need to be set in the prod build pipeline to "https://phlask-prod.firebaseio.com"
+// https://github.com/phlask/phlask-map/issues/498
+let phlaskDatabaseUrl = process.env.REACT_APP_DB_URL || "https://phlask-test.firebaseio.com"
+
+export const resourcesConfig = {
   apiKey: 'AIzaSyABw5Fg78SgvedyHr8tl-tPjcn5iFotB6I',
   authDomain: 'phlask-web-map.firebaseapp.com',
-  databaseURL: 'https://phlask-contributors.firebaseio.com/',
+  databaseURL: phlaskDatabaseUrl,
   projectId: 'phlask-web-map',
   storageBucket: 'phlask-web-map.appspot.com',
   messagingSenderId: '428394983826'
 };
 
-export const resourcesConfig = {
+export const contributorsConfig = {
   apiKey: 'AIzaSyABw5Fg78SgvedyHr8tl-tPjcn5iFotB6I',
   authDomain: 'phlask-web-map.firebaseapp.com',
-  databaseURL: 'https://phlask-beta.firebaseio.com',
+  databaseURL: 'https://phlask-contributors.firebaseio.com/',
   projectId: 'phlask-web-map',
   storageBucket: 'phlask-web-map.appspot.com',
   messagingSenderId: '428394983826'


### PR DESCRIPTION
# Pull Request

## Change Summary

- A simple one-liner added to `firebaseConfig.json` that sets the Firebase DB URL based on the presence of an environment variable `REACT_APP_DB_URL`. If `REACT_APP_DB_URL` is not present, it will default to the test database URL.
- The Github action that builds the Docker image was updated to use `REACT_APP_DB_URL`. 
- Unused `utils.js` file removed

## Change Reason

Contributors to the project are typically testing, and any changes made (e.g. adding a resource) will be reflected on the production database. This is not ideal and leads to a lot of data cleanup actions. This change ensures the test database will be used by default unless the developer wants to force use the prod DB.

## Testing
Tested locally the environment variable override works and by resources retrieved/added are done to to the proper DB. 

For the GitHub Action, we'll want to deploy the beta site and then confirm resource changes are made to the production DB.

## Verification [Optional]

Closes #498 

