### PR TITLE
Fixes deprecation of docker compose v1 by changing to v2 syntax

### DIFF
--- a/.github/workflows/betasite.yml
+++ b/.github/workflows/betasite.yml
@@ -25,7 +25,7 @@ jobs:
       run: |
          echo Build started on `date`
          echo Building the webapp...
-         docker-compose run prod_build
+         docker compose run prod_build
          echo Build completed on `date`
          echo Pushing the webapp to S3...
          aws s3 sync docker/build s3://beta.phlask.me --acl public-read --delete

--- a/.github/workflows/build_testsite.yml
+++ b/.github/workflows/build_testsite.yml
@@ -19,7 +19,7 @@ jobs:
         run: |
           echo Build started on `date`
           echo Building the webapp...
-          docker-compose run prod_build
+          docker compose run prod_build
           echo Build completed on `date`
           echo Pushing the webapp to S3...
           aws s3 sync docker/build s3://test.phlask.me/${GITHUB_SHA} --acl public-read --delete

--- a/.github/workflows/prodsite.yml
+++ b/.github/workflows/prodsite.yml
@@ -25,7 +25,7 @@ jobs:
       run: |
          echo Build started on `date`
          echo Building the webapp...
-         docker-compose run prod_build
+         docker compose run prod_build
          echo Build completed on `date`
          echo Pushing the webapp to S3...
          aws s3 sync docker/build s3://phlask.me --acl public-read --delete

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Code behind the PHLASK Web Map
 │   ├── fixtures                       <-- Fixtures for mocked out data
 │   └── integration                    <-- Source files for unit tests
 ├── cypress.json
-├── docker-compose.yml
+├── docker compose.yml
 ├── package-lock.json
 ├── package.json
 ├── public
@@ -79,7 +79,7 @@ Note that `core hours per month` means each core on your codespace consumes inde
 
 1.  Clone this repo: `git clone git@github.com:phlask/phlask-map.git`
 1.  Navigate to the root of the cloned repo: `cd phlask-map`
-1.  Build the container with docker-compose: `docker-compose build app`.
+1.  Build the container with docker compose: `docker compose build app`.
 
     Note: this may take awhile. In the past this has taken ~5 minutes. If this step takes longer than 10 minutes, kill the process and try again. Final output should look like this:
 
@@ -89,7 +89,7 @@ Note that `core hours per month` means each core on your codespace consumes inde
     => => writing image sha256:c98c...
     ```
 
-1.  Run the container with docker-compose: `docker-compose up app`
+1.  Run the container with docker compose: `docker compose up app`
 
     Note: this may take awhile. Once the application is up, output similar to this should be printed out to the console:
 


### PR DESCRIPTION
# Pull Request

## Change Summary

Responding to the docker compose v1 deprecation posted by GitHub: https://github.blog/changelog/2024-04-10-github-hosted-runner-images-deprecation-notice-docker-compose-v1/ 

## Change Reason

The deprecation mentioned above is breaking our test and beta site builds.

## Verification [Optional]

See the passing GitHub checks attached to this PR for verification.

We recommend using [OBS](https://obsproject.com/) to record videos, as it is open source, free, and available on all major operating systems.

Related Issue: N/A

