### PR TITLE
Make beta the source of truth and default for now

### DIFF
--- a/src/firebase/firebaseConfig.js
+++ b/src/firebase/firebaseConfig.js
@@ -1,7 +1,7 @@
 // Sets the Phlask Database URL to use the test instance unless overriden
 // This environment variable will also need to be set in the prod build pipeline to "https://phlask-prod.firebaseio.com"
 // https://github.com/phlask/phlask-map/issues/498
-let phlaskDatabaseUrl = process.env.REACT_APP_DB_URL || "https://phlask-test.firebaseio.com"
+let phlaskDatabaseUrl = process.env.REACT_APP_DB_URL || "https://phlask-beta.firebaseio.com"
 
 export const resourcesConfig = {
   apiKey: 'AIzaSyABw5Fg78SgvedyHr8tl-tPjcn5iFotB6I',


### PR DESCRIPTION
The test DB is no currently up to date, so for now we should always be using the beta site. In the future, we will dynamically allow for the test site once we sync everything up.