### PR TITLE
Updated spacing below expanded toolbar and below subtitles

### DIFF
--- a/src/components/SelectedTapDetails/SelectedTapDetails.module.scss
+++ b/src/components/SelectedTapDetails/SelectedTapDetails.module.scss
@@ -95,9 +95,11 @@ $lighter-grey: #e9eef4;
   .expandedToolBar {
     display: flex;
     justify-content: space-between;
+    margin-bottom: 8px;
   }
 
   .subtitles {
     line-height: 20px;
+    margin-bottom: 0.1rem;
   }
 }


### PR DESCRIPTION
# Pull Request
addressing selectedTap modal design review, issue #423

## Change Summary

![image](https://github.com/user-attachments/assets/b0a4c0a2-3385-4dc4-a6df-c783f36258d0)

## Change Reason

design review


Related Issue: closes #423

