### PR TITLE
Make sure to treat forage_type as a list

### DIFF
--- a/src/components/SelectedTapDetails/SelectedTapDetails.js
+++ b/src/components/SelectedTapDetails/SelectedTapDetails.js
@@ -288,7 +288,7 @@ function getTagsFromResource(resource) {
     tags.push(...(resource.food.organization_type || []));
   }
   if (resource.forage) {
-    tags.push(resource.forage.forage_type);
+    tags.push(...(resource.forage.forage_type || []));
   }
 
   return tags.filter(Boolean).sort(); // Tags are optional, so filter out missing tags too


### PR DESCRIPTION
This was a bug that Billy found when adding a foraging site. It turns out there was an issue where we were trying to show the foraging_type as a string when it was actually a list of possible options.