### PR TITLE
Adds overflow to the SelectedTap component to ensure some scrolling is available for shorter screens

### DIFF
--- a/src/components/SelectedTap/SelectedTap.js
+++ b/src/components/SelectedTap/SelectedTap.js
@@ -220,7 +220,9 @@ const SelectedTap = () => {
               top: '20px',
               width: '708px',
               height: '700px',
-              borderRadius: '10px'
+              borderRadius: '10px',
+              maxHeight: '100%',
+              overflow: 'auto'
             }}
           >
             <SelectedTapDetails


### PR DESCRIPTION
# Pull Request

## Change Summary

Adds overflow to the SelectedTap component to ensure some scrolling is available for shorter screens. This is not a complete fix, so this will not close the related issue, but it will at least minimize the impact of overflow to users in these specific scenarios.

## Change Reason

See #531 for rationale.

## Verification [Optional]

A .gif, video, or screenshots of the feature are extremely helpful in verifying that code changes are working correctly. Feel free to include them in the PR to help the reviewer.

We recommend using [OBS](https://obsproject.com/) to record videos, as it is open source, free, and available on all major operating systems.

Related Issue: #531 

