### PR TITLE
Adds a useEffect hook to address the Google Maps component not updating zoom controls via property change

### DIFF
--- a/cypress/e2e/desktop/siteInfo.cy.js
+++ b/cypress/e2e/desktop/siteInfo.cy.js
@@ -26,7 +26,6 @@ describe('site info', () => {
     // Load a sample food site
     // This is currently using live data, but should be updated to make use of test data.
     cy.get('[title=data-cy-1]').click();
-    cy.get('[title=data-cy-2]').click();
 
     cy.get('[data-cy=tap-organization-name]').should(
       'have.text',

--- a/src/components/ReactGoogleMaps/ReactGoogleMaps.js
+++ b/src/components/ReactGoogleMaps/ReactGoogleMaps.js
@@ -228,6 +228,17 @@ export const ReactGoogleMaps = ({ google }) => {
     JSON.parse(JSON.stringify(noActiveFilterTags))
   );
 
+  // The Map component from the google-maps-react library does not update
+  // when the zoomControl property is changed. Therefore, using "useEffect"
+  // to influence the change via the Google Maps Javascript API instead.
+  useEffect(() => {
+    if (map) {
+      map.setOptions({
+        zoomControl: !isMobile
+      })
+    }
+  })
+
   useEffect(() => {
     if (!allResources.length) {
       dispatch(getResources());
@@ -349,7 +360,6 @@ export const ReactGoogleMaps = ({ google }) => {
             className="map"
             style={style}
             zoom={zoom}
-            zoomControl={!isMobile}
             streetViewControl={false}
             mapTypeControl={false}
             rotateControl={false}


### PR DESCRIPTION
# Pull Request

## Change Summary

Implements a fix to ensure that Google Maps zoom controls are not shown when switching the map from Desktop to Mobile view

## Change Reason

Bug reported on #525 

## Verification [Optional]

A .gif, video, or screenshots of the feature are extremely helpful in verifying that code changes are working correctly. Feel free to include them in the PR to help the reviewer.

We recommend using [OBS](https://obsproject.com/) to record videos, as it is open source, free, and available on all major operating systems.

Related Issue: #525 

