### PR TITLE
[Issue 460] Catches goecoding issue before reaching submission

### DIFF
--- a/src/components/AddResourceModal/AddBathroom/AddBathroom.jsx
+++ b/src/components/AddResourceModal/AddBathroom/AddBathroom.jsx
@@ -33,7 +33,8 @@ function AddBathroom({
   handicapAccessible,
   hasFountain,
   checkboxChangeHandler,
-  textFieldChangeHandler
+  textFieldChangeHandler,
+  isValidAddress
 }) {
   const isMobile = useIsMobile();
   const userLocation = useSelector(state => state.filterMarkers.userLocation);
@@ -97,6 +98,7 @@ function AddBathroom({
                 control={control}
                 setValue={setValue}
                 textFieldChangeHandler={textFieldChangeHandler}
+                isValidAddress={isValidAddress}
               />
             )}
             {(page === 1 || isMobile) && (

--- a/src/components/AddResourceModal/AddBathroom/PageOne.jsx
+++ b/src/components/AddResourceModal/AddBathroom/PageOne.jsx
@@ -40,7 +40,8 @@ const PageOne = ({
   errors,
   control,
   setValue,
-  textFieldChangeHandler
+  textFieldChangeHandler,
+  isValidAddress
 }) => {
   const isMobile = useIsMobile();
 
@@ -90,7 +91,10 @@ const PageOne = ({
       </Grid>
       <Grid item xs={12} xm={12} lg={6} xl={6}>
         <Controller
-          rules={{ required: true }}
+          rules={{
+            required: true,
+            validate: value => isValidAddress || 'Please enter a valid address'
+          }}
           control={control}
           name="address"
           defaultValue={''}
@@ -126,7 +130,11 @@ const PageOne = ({
                     }}
                     helperText={
                       <Stack component={'span'}>
-                        {errors.address && requiredFieldMsg}
+                        {errors.address && (
+                          <span>
+                            {errors.address.message || requiredFieldMsg}
+                          </span>
+                        )}
                         <Link>
                           {'Use my location instead  '}
                           <MyLocationIcon sx={{ fontSize: 10 }} />

--- a/src/components/AddResourceModal/AddFood/AddFood.jsx
+++ b/src/components/AddResourceModal/AddFood/AddFood.jsx
@@ -39,7 +39,8 @@ function AddFood({
   distributionTypeOther,
   guidelines,
   checkboxChangeHandler,
-  textFieldChangeHandler
+  textFieldChangeHandler,
+  isValidAddress
 }) {
   const isMobile = useIsMobile();
   const getVariableName = variable => Object.keys(variable)[0];
@@ -120,6 +121,7 @@ function AddFood({
                 getVariableName={getVariableName}
                 checkboxChangeHandler={checkboxChangeHandler}
                 textFieldChangeHandler={textFieldChangeHandler}
+                isValidAddress={isValidAddress}
               />
             )}
             {(page === 1 || isMobile) && (

--- a/src/components/AddResourceModal/AddFood/PageOne.jsx
+++ b/src/components/AddResourceModal/AddFood/PageOne.jsx
@@ -50,7 +50,8 @@ const PageOne = ({
   setValue,
   getVariableName,
   checkboxChangeHandler,
-  textFieldChangeHandler
+  textFieldChangeHandler,
+  isValidAddress
 }) => {
   const isMobile = useIsMobile();
 
@@ -160,7 +161,10 @@ const PageOne = ({
       </Grid>
       <Grid item xs={12} xm={12} lg={6} xl={6}>
         <Controller
-          rules={{ required: true }}
+          rules={{
+            required: true,
+            validate: value => isValidAddress || 'Please enter a valid address'
+          }}
           control={control}
           name="address"
           defaultValue={''}
@@ -196,7 +200,11 @@ const PageOne = ({
                     }}
                     helperText={
                       <Stack component={'span'}>
-                        {errors.address && requiredFieldMsg}
+                        {errors.address && (
+                          <span>
+                            {errors.address.message || requiredFieldMsg}
+                          </span>
+                        )}
                         <Link>
                           {'Use my location instead  '}
                           <MyLocationIcon sx={{ fontSize: 10 }} />

--- a/src/components/AddResourceModal/AddForaging/AddForaging.jsx
+++ b/src/components/AddResourceModal/AddForaging/AddForaging.jsx
@@ -38,7 +38,8 @@ function AddForaging({
   inSeason,
   communityGarden,
   checkboxChangeHandler,
-  textFieldChangeHandler
+  textFieldChangeHandler,
+  isValidAddress
 }) {
   const isMobile = useIsMobile();
   const userLocation = useSelector(state => state.filterMarkers.userLocation);
@@ -123,6 +124,7 @@ function AddForaging({
                 getVariableName={getVariableName}
                 checkboxChangeHandler={checkboxChangeHandler}
                 textFieldChangeHandler={textFieldChangeHandler}
+                isValidAddress={isValidAddress}
               />
             )}
             {(page === 1 || isMobile) && (

--- a/src/components/AddResourceModal/AddForaging/PageOne.jsx
+++ b/src/components/AddResourceModal/AddForaging/PageOne.jsx
@@ -54,7 +54,8 @@ const PageOne = ({
   setValue,
   getVariableName,
   checkboxChangeHandler,
-  textFieldChangeHandler
+  textFieldChangeHandler,
+  isValidAddress
 }) => {
   const isMobile = useIsMobile();
 
@@ -138,7 +139,10 @@ const PageOne = ({
       </Grid>
       <Grid item xs={12} xm={12} lg={6} xl={6}>
         <Controller
-          rules={{ required: true }}
+          rules={{
+            required: true,
+            validate: value => isValidAddress || 'Please enter a valid address'
+          }}
           control={control}
           name="address"
           defaultValue={''}
@@ -174,7 +178,11 @@ const PageOne = ({
                     }}
                     helperText={
                       <Stack component={'span'}>
-                        {errors.address && requiredFieldMsg}
+                        {errors.address && (
+                          <span>
+                            {errors.address.message || requiredFieldMsg}
+                          </span>
+                        )}
                         <Link>
                           {'Use my location instead  '}
                           <MyLocationIcon sx={{ fontSize: 10 }} />

--- a/src/components/AddResourceModal/AddResourceModalV2.jsx
+++ b/src/components/AddResourceModal/AddResourceModalV2.jsx
@@ -42,6 +42,7 @@ const AddResourceModalV2 = props => {
     closeModal: false,
     latitude: null,
     longitude: null,
+    isValidAddress: false,
 
     // ADD WATER
     filtration: false,
@@ -116,10 +117,16 @@ const AddResourceModalV2 = props => {
         setValues(prevValues => ({
           ...prevValues,
           latitude: lat,
-          longitude: lng
+          longitude: lng,
+          isValidAddress: true
         }));
       })
-      .catch(noop);
+      .catch(() => {
+        setValues(prevValues => ({
+          ...prevValues,
+          isValidAddress: false
+        }));
+      });
   }, 500); // 500ms debounce delay
 
   const textFieldChangeHandler = eventOrString => {
@@ -406,6 +413,7 @@ const AddResourceModalV2 = props => {
           guidelines={values.guidelines}
           checkboxChangeHandler={checkboxChangeHandler}
           textFieldChangeHandler={textFieldChangeHandler}
+          isValidAddress={values.isValidAddress}
         />
       )}
 
@@ -438,6 +446,7 @@ const AddResourceModalV2 = props => {
           guidelines={values.guidelines}
           checkboxChangeHandler={checkboxChangeHandler}
           textFieldChangeHandler={textFieldChangeHandler}
+          isValidAddress={values.isValidAddress}
         />
       )}
 
@@ -464,6 +473,7 @@ const AddResourceModalV2 = props => {
           hasFountain={values.hasFountain}
           checkboxChangeHandler={checkboxChangeHandler}
           textFieldChangeHandler={textFieldChangeHandler}
+          isValidAddress={values.isValidAddress}
         />
       )}
 
@@ -493,6 +503,7 @@ const AddResourceModalV2 = props => {
           communityGarden={values.communityGarden}
           checkboxChangeHandler={checkboxChangeHandler}
           textFieldChangeHandler={textFieldChangeHandler}
+          isValidAddress={values.isValidAddress}
         />
       )}
 

--- a/src/components/AddResourceModal/AddWaterTap/AddWaterTap.jsx
+++ b/src/components/AddResourceModal/AddWaterTap/AddWaterTap.jsx
@@ -42,7 +42,8 @@ function AddWaterTap({
   // Other
   guidelines,
   checkboxChangeHandler,
-  textFieldChangeHandler
+  textFieldChangeHandler,
+  isValidAddress
 }) {
   const isMobile = useIsMobile();
   const userLocation = useSelector(state => state.filterMarkers.userLocation);
@@ -122,6 +123,7 @@ function AddWaterTap({
                 getVariableName={getVariableName}
                 checkboxChangeHandler={checkboxChangeHandler}
                 textFieldChangeHandler={textFieldChangeHandler}
+                isValidAddress={isValidAddress}
               />
             )}
             {(page === 1 || isMobile) && (

--- a/src/components/AddResourceModal/AddWaterTap/PageOne.jsx
+++ b/src/components/AddResourceModal/AddWaterTap/PageOne.jsx
@@ -58,7 +58,8 @@ const PageOne = ({
   setValue,
   getVariableName,
   checkboxChangeHandler,
-  textFieldChangeHandler
+  textFieldChangeHandler,
+  isValidAddress
 }) => {
   const isMobile = useIsMobile();
 
@@ -151,7 +152,10 @@ const PageOne = ({
       </Grid>
       <Grid item xs={12} xm={12} lg={6} xl={6}>
         <Controller
-          rules={{ required: true }}
+          rules={{
+            required: true,
+            validate: value => isValidAddress || 'Please enter a valid address'
+          }}
           control={control}
           name="address"
           defaultValue={''}
@@ -187,7 +191,11 @@ const PageOne = ({
                     }}
                     helperText={
                       <Stack component={'span'}>
-                        {errors.address && requiredFieldMsg}
+                        {errors.address && (
+                          <span>
+                            {errors.address.message || requiredFieldMsg}
+                          </span>
+                        )}
                         <Link>
                           {'Use my location instead  '}
                           <MyLocationIcon sx={{ fontSize: 10 }} />


### PR DESCRIPTION
# Pull Request

## Change Summary

This PR fixes a bug where addresses that aren't real or don't have a valid lat/lng would cause the app to crash without any indication to the user.

This change "fixes" it by catching this issue before we even get to submission - if the address is not an address that would result in a latitude and longitude, an error is shown saying that it is not a valid address.

<img width="667" alt="Screenshot 2024-11-30 at 4 39 00 PM" src="https://github.com/user-attachments/assets/c94754d2-bd8e-42ed-80ea-cd90f1167be5">

## Verification

Here is a video of this being demonstrated: https://www.loom.com/share/a0964ad0e4e7443491f9f0ce09cd1a87?sid=1467be47-5d0f-4e02-be58-e4642604561c

Related Issue: #460 

