### PR TITLE
Use clearAllTags() iinstead of dispatch(resetFilterFunction())

### DIFF
--- a/src/components/ChooseResourceType/ChooseResourceType.js
+++ b/src/components/ChooseResourceType/ChooseResourceType.js
@@ -7,9 +7,9 @@ const ChooseResourceType = props => {
   return (
     <>
       {!isMobile ? (
-        <DesktopChooseResourceType resourceTypeInfo={props.resourceTypeInfo} />
+        <DesktopChooseResourceType resourceTypeInfo={props.resourceTypeInfo} clearAllTags={props.clearAllTags} />
       ) : (
-        <MobileChooseResourceType resourceTypeInfo={props.resourceTypeInfo} />
+        <MobileChooseResourceType resourceTypeInfo={props.resourceTypeInfo} clearAllTags={props.clearAllTags} />
       )}
     </>
   );

--- a/src/components/ChooseResourceType/DesktopChooseResourceType.js
+++ b/src/components/ChooseResourceType/DesktopChooseResourceType.js
@@ -6,7 +6,6 @@ import { useRef } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 
 import {
-  resetFilterFunction,
   setResourceType,
   setToolbarModal,
   TOOLBAR_MODAL_NONE,
@@ -31,7 +30,7 @@ const DesktopResourceButton = props => {
         borderRadius: '8px'
       }}
       onClick={() => {
-        dispatch(resetFilterFunction());
+        props.clearAllTags();
         dispatch(setResourceType(props.type));
       }}
       data-cy={props['data-cy']}
@@ -89,6 +88,7 @@ function DesktopChooseResourceType(props) {
                   key={entry.type}
                   {...entry}
                   data-cy={`button-${entry.type}-data-selector`}
+                  clearAllTags={props.clearAllTags}
                 />
               ))}
             </Box>

--- a/src/components/ChooseResourceType/MobileChooseResourceType.js
+++ b/src/components/ChooseResourceType/MobileChooseResourceType.js
@@ -1,16 +1,15 @@
 import Box from '@mui/material/Box';
 import Dialog from '@mui/material/Dialog';
-import List from '@mui/material/List';
-import Slide from '@mui/material/Slide';
 import Grid from '@mui/material/Grid';
+import List from '@mui/material/List';
 import ListItemButton from '@mui/material/ListItemButton';
 import ListItemIcon from '@mui/material/ListItemIcon';
 import ListItemText from '@mui/material/ListItemText';
+import Slide from '@mui/material/Slide';
 import Typography from '@mui/material/Typography';
 import { useDispatch, useSelector } from 'react-redux';
 
 import {
-  resetFilterFunction,
   setResourceType,
   setToolbarModal,
   TOOLBAR_MODAL_NONE,
@@ -38,7 +37,7 @@ const MobileResourceButton = props => {
     <ListItemButton
       sx={{ alignItems: 'end' }}
       onClick={() => {
-        dispatch(resetFilterFunction());
+        props.clearAllTags();
         switchType(props.type);
       }}
     >
@@ -88,7 +87,7 @@ const MobileChooseResourceType = props => {
         >
           <List sx={{ maxWidth: 210 }}>
             {props.resourceTypeInfo.map(entry => (
-              <MobileResourceButton key={entry.type} {...entry} />
+              <MobileResourceButton key={entry.type} {...entry} clearAllTags={props.clearAllTags} />
             ))}
           </List>
         </Slide>

--- a/src/components/ReactGoogleMaps/ReactGoogleMaps.js
+++ b/src/components/ReactGoogleMaps/ReactGoogleMaps.js
@@ -1,13 +1,11 @@
 import { Fade } from '@mui/material';
 import Stack from '@mui/material/Stack';
-import { CITY_HALL_COORDINATES } from 'constants/defaults';
 import { GoogleApiWrapper, Map, Marker } from 'google-maps-react';
 import useIsMobile from 'hooks/useIsMobile';
 import { useEffect, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import ReactTouchEvents from 'react-touch-events';
 import {
-  TOOLBAR_MODAL_SEARCH,
   getResources,
   removeEntryFilterFunction,
   removeFilterFunction,
@@ -424,7 +422,7 @@ export const ReactGoogleMaps = ({ google }) => {
             search={location => searchForLocation(location)}
           />
         </Stack>
-        <ChooseResourceType resourceTypeInfo={resourceTypeInfo} />
+        <ChooseResourceType resourceTypeInfo={resourceTypeInfo} clearAllTags={clearAllTags} />
         <Filter
           resourceType={resourceType}
           filters={filters}


### PR DESCRIPTION
# Pull Request

## Change Summary

Switching between resources now also visually resets the filter.

## Change Reason

If a user has a filter / filters selected on resource type A (ex- Water), switches to resource type B (ex- Food) and then goes back to resource type A, all the filters are visually toggled "on" but the filters are not filtering the list. A user has to toggle them off and on again to get them to apply.

Related Issue: #541 

