### PR TITLE
Switches markers to use id property as key

### DIFF
--- a/index.html
+++ b/index.html
@@ -57,11 +57,6 @@
       integrity="sha384-cs/chFZiN24E4KMATLdqdvsezGxaGsi4hLGOzlXwp5UZB1LY//20VyM2taTB4QvJ"
       crossorigin="anonymous"
     ></script>
-    <script
-      src="https://stackpath.bootstrapcdn.com/bootstrap/4.1.0/js/bootstrap.min.js"
-      integrity="sha384-uefMccjFJAIv6A+rW+L4AHf99KvxDjWSu1z9VI8SKNVmz4sk7buKt/6v9KI65qnm"
-      crossorigin="anonymous"
-    ></script>
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>

--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
     "@vis.gl/react-google-maps": "^1.4.0",
     "bootstrap": "^5.1.3",
     "cypress": "^13.6.6",
-    "google-maps-react": "^2.0.6",
     "popper.js": "^1.16.1",
     "react": "^18.3.1",
     "react-div-100vh": "^0.7.0",

--- a/src/components/ReactGoogleMaps/ReactGoogleMaps.jsx
+++ b/src/components/ReactGoogleMaps/ReactGoogleMaps.jsx
@@ -258,7 +258,7 @@ const ReactGoogleMaps = () => {
       >
         {filteredResources.map((resource, index) => (
           <Marker
-            key={resource.date_created}
+            key={resource.id}
             onClick={() => {
               onMarkerClick(resource);
             }}

--- a/yarn.lock
+++ b/yarn.lock
@@ -3417,11 +3417,6 @@ globrex@^0.1.2:
   resolved "https://registry.yarnpkg.com/globrex/-/globrex-0.1.2.tgz#dd5d9ec826232730cd6793a5e33a9302985e6098"
   integrity sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg==
 
-google-maps-react@^2.0.6:
-  version "2.0.6"
-  resolved "https://registry.yarnpkg.com/google-maps-react/-/google-maps-react-2.0.6.tgz#0473356207ab6b47227b393b89e4b83f6eab06da"
-  integrity sha512-M8Eo9WndfQEfxcmm6yRq03qdJgw1x6rQmJ9DN+a+xPQ3K7yNDGkVDbinrf4/8vcox7nELbeopbm4bpefKewWfQ==
-
 gopd@^1.0.1, gopd@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/gopd/-/gopd-1.2.0.tgz#89f56b8217bdbc8802bd299df6d7f1081d7e51a1"


### PR DESCRIPTION
# Pull Request

## Change Summary

It seems that the bug described below is related to the fact that we've been using the `created_date` property on the data to create a unique key for each tap element on the map. That key is not necessarily unique.

We didn't have a proper unique id on firebase, but I noticed that the data in supabase seems to have a new `id` property. Switching to that property seems to remove any instances of lingering resources, which can also be confirmed by checking the console, which reports errors when there are multiple keys.

## Change Reason

Addresses an ongoing bug where food taps would linger on the map, even when changing the map to display non-food-type resources.

Related Issue: N/A, this was addressed without an open issue

