### PR TITLE
Fix key issue in contributors list

### DIFF
--- a/src/components/ContributorsList/ContributorsList.jsx
+++ b/src/components/ContributorsList/ContributorsList.jsx
@@ -5,19 +5,16 @@ import Typography from '@mui/material/Typography';
 import ContributorsListItem from './ContributorsListItem';
 
 const ContributorsList = ({ items = [], title = 'Contributors' }) => (
-    <Grid item>
-      <Typography variant="h6" color="#73839E">
-        {title}
-      </Typography>
-      <List>
-        {items.map(contributor => (
-          <ContributorsListItem
-            key={contributor.key}
-            contributor={contributor}
-          />
-        ))}
-      </List>
-    </Grid>
-  );
+  <Grid item>
+    <Typography variant="h6" color="#73839E">
+      {title}
+    </Typography>
+    <List>
+      {items.map(contributor => (
+        <ContributorsListItem key={contributor.id} contributor={contributor} />
+      ))}
+    </List>
+  </Grid>
+);
 
 export default ContributorsList;


### PR DESCRIPTION
# Pull Request

## Change Summary

Change the key prop for the contributors to account for the data migration to Supabase

## Change Reason

We changed database and not we no longer have a "Key" field for contributors, so React was complaining that the contributors list is missing the key prop

