### PR TITLE
Fixes disabled scrollbars appearing in the add resource modal in some browser/OS configurations

### DIFF
--- a/src/components/AddResourceModal/AddBathroom/AddBathroom.jsx
+++ b/src/components/AddResourceModal/AddBathroom/AddBathroom.jsx
@@ -64,7 +64,7 @@ const AddBathroom = ({
   }
 
   return (
-    <Box overflow="scroll" justifyContent="center">
+    <Box overflow="none" justifyContent="center">
       <Box
         sx={{
           display: 'flex',

--- a/src/components/AddResourceModal/AddFood/AddFood.jsx
+++ b/src/components/AddResourceModal/AddFood/AddFood.jsx
@@ -81,7 +81,7 @@ const AddFood = ({
   return (
     <Card
       style={{
-        overflow: 'scroll',
+        overflow: 'none',
         justifyContent: 'center'
       }}
     >

--- a/src/components/AddResourceModal/AddForaging/AddForaging.jsx
+++ b/src/components/AddResourceModal/AddForaging/AddForaging.jsx
@@ -80,7 +80,7 @@ const AddForaging = ({
   return (
     <Card
       style={{
-        overflow: 'scroll',
+        overflow: 'none',
         justifyContent: 'center'
       }}
     >

--- a/src/components/AddResourceModal/AddWaterTap/AddWaterTap.jsx
+++ b/src/components/AddResourceModal/AddWaterTap/AddWaterTap.jsx
@@ -74,7 +74,7 @@ const AddWaterTap = ({
   }
 
   return (
-    <Box justifyContent="center">
+    <Box justifyContent="center" overflow="none">
       <Box
         sx={{
           display: 'flex',


### PR DESCRIPTION
# Pull Request

## Change Summary

A previous PR had intended to fix this, but the change had only been applied to adding Water resources. This PR extends the fix to all resource types and makes the fix more explicit by ensuring we are not showing an unnecessary scrollbar.

## Change Reason

Summary of why changes are being made. Link to other documents, Slack conversations, etc are good to post here for explaining the reason for particular changes.

## Verification [Optional]

A .gif, video, or screenshots of the feature are extremely helpful in verifying that code changes are working correctly. Feel free to include them in the PR to help the reviewer.

We recommend using [OBS](https://obsproject.com/) to record videos, as it is open source, free, and available on all major operating systems.

Related Issue: N/A

