### PR TITLE
Handles case where resourceType details are not present in the database for some resources

### DIFF
--- a/src/selectors/resourceSelectors.js
+++ b/src/selectors/resourceSelectors.js
@@ -89,7 +89,7 @@ const selectFilteredResource = createSelector(
         tags.forEach(tag => {
           const tagFormatted = tagMapping[tag];
           // check to make sure resource has property with filter info
-          if (resourceTypeFormatted in resource) {
+          if (resourceTypeFormatted in resource && resource[resourceTypeFormatted] !== null) {
             let tagFound = false;
             // loop through filter info types to find filter value
             propertyMapping[resourceType].forEach(prop => {


### PR DESCRIPTION
# Pull Request

## Change Summary

While filtering, all resources are expected to have a `resourceType` property that includes type-unique properties. However,  some resources do not have this property. This results in a crash when trying to filter resources. This PR may not be needed if the database can enforce the presence of the relevant property for a given resource.

## Change Reason

During a PHLASK demo, showing the filter feature caused the site to crash.

## Verification [Optional]

N/A

Related Issue: N/A

