### PR TITLE
Fix search suggestion click issue on Chrome/Safari Desktop

### DIFF
--- a/src/components/SearchBar/SearchBar.jsx
+++ b/src/components/SearchBar/SearchBar.jsx
@@ -140,7 +140,7 @@ const SearchBar = ({ search }) => {
 
                       return (
                         <div
-                          key={crypto.randomUUID()}
+                          key={key}
                           id={id}
                           role="option"
                           onMouseEnter={onMouseEnter}
@@ -247,7 +247,7 @@ const SearchBar = ({ search }) => {
                     return (
                       <div
                         className={className}
-                        key={crypto.randomUUID()}
+                        key={key}
                         id={suggestion.id}
                         role="option"
                         onMouseEnter={onMouseEnter}


### PR DESCRIPTION
# Pull Request

## Change Summary

Fix search suggestion click issues on Chrome/Safari Desktop by replacing unstable crypto.randomUUID() keys with stable library keys. This prevents DOM recreation during hover state changes that was interrupting click events.

## Change Reason

Users were unable to reliably click on search suggestions in Chrome and Safari desktop browsers due to DOM elements being recreated on hover, which interrupted the click event.

## Changes
- Mobile: Changed line 143 from `crypto.randomUUID()` to `key={key}`  
- Desktop: Changed line 250 from `crypto.randomUUID()` to `key={key}`

Related Issue: #637