### PR TITLE
648: add edit button to resource detail modal

### DIFF
--- a/src/components/SelectedTap/SelectedTap.jsx
+++ b/src/components/SelectedTap/SelectedTap.jsx
@@ -32,6 +32,8 @@ const SelectedTap = () => {
 
   const [walkingDuration, setWalkingDuration] = useState(0);
   const [infoCollapseMobile, setInfoCollapseMobile] = useState(false);
+  const [isEditing, setIsEditing] = useState(false);
+  const [editingResource, setEditingResource] = useState(null);
 
   const showingInfoWindow = useSelector(
     state => state.filterMarkers.showingInfoWindow
@@ -80,6 +82,11 @@ const SelectedTap = () => {
   const animateInfoExpansion = shouldExpand => {
     setInfoExpansionStyle({ height: shouldExpand ? '80%' : previewHeight });
     dispatch(toggleInfoExpanded(shouldExpand));
+  };
+
+  const handleStartEdit = resource => {
+    setIsEditing(true);
+    setEditingResource(resource);
   };
 
   const handleToggleInfoWindow = isShown => {
@@ -186,6 +193,11 @@ const SelectedTap = () => {
                 infoCollapse={infoCollapseMobile}
                 setInfoCollapse={setInfoCollapseMobile}
                 isMobile
+                isEditing={isEditing}
+                setIsEditing={setIsEditing}
+                editingResource={editingResource}
+                setEditingResource={setEditingResource}
+                onStartEdit={handleStartEdit}
               >
                 <SelectedTapHours
                   infoIsExpanded={infoIsExpanded}
@@ -219,6 +231,11 @@ const SelectedTap = () => {
               setInfoCollapse={setInfoCollapseMobile}
               isMobile={false}
               closeModal={() => handleToggleInfoWindow(false)}
+              isEditing={isEditing}
+              setIsEditing={setIsEditing}
+              editingResource={editingResource}
+              setEditingResource={setEditingResource}
+              onStartEdit={handleStartEdit}
             >
               <SelectedTapHours infoIsExpanded selectedPlace={selectedPlace} />
             </SelectedTapDetails>

--- a/src/components/SelectedTapDetails/SelectedTapDetails.jsx
+++ b/src/components/SelectedTapDetails/SelectedTapDetails.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { Button, Collapse, IconButton, SvgIcon, Menu, MenuItem } from '@mui/material';
 import { styled } from '@mui/material/styles';
 import CloseIcon from '@mui/icons-material/Close';
-import MoreVertIcon from '@mui/icons-material/MoreVert';
+import MoreHorizIcon from '@mui/icons-material/MoreHoriz';
 
 import DirectionIcon from 'icons/ArrowElbowUpRight';
 import CaretDownSvg from 'icons/CaretDown';
@@ -263,13 +263,13 @@ const SelectedTapDetails = ({
         <button className={styles.swipeIcon} aria-label="swipe" type="button" />
       ) : (
         <div className={styles.expandedToolBar}>
-          <div>
+          <div className={styles.toolbarActions}>
             <IconButton
-              color="primary"
               aria-label="more options"
               onClick={handleMenuOpen}
+              sx={{ color: '#2D3748' }}
             >
-              <MoreVertIcon />
+              <MoreHorizIcon />
             </IconButton>
             <Menu
               anchorEl={menuAnchor}
@@ -277,8 +277,16 @@ const SelectedTapDetails = ({
               onClose={handleMenuClose}
             >
               <MenuItem onClick={handleSuggestEdit}>Suggest Edit</MenuItem>
-              <MenuItem>Report</MenuItem>
+              <MenuItem onClick={handleMenuClose} sx={{ color: '#EF4444' }}>Report</MenuItem>
             </Menu>
+            <IconButton
+              color="primary"
+              aria-label="share"
+              component="label"
+              onClick={toggleNativeShare}
+            >
+              <ExportSvg />
+            </IconButton>
           </div>
           {/* On mobile, show the minimize button. On desktop, show the close button */}
           {isMobile && (

--- a/src/components/SelectedTapDetails/SelectedTapDetails.jsx
+++ b/src/components/SelectedTapDetails/SelectedTapDetails.jsx
@@ -123,7 +123,12 @@ const SelectedTapDetails = ({
   isMobile,
   closeModal,
   selectedPlace,
-  children
+  children,
+  isEditing,
+  setIsEditing,
+  editingResource,
+  setEditingResource,
+  onStartEdit
 }) => {
   /**
    * @type {ResourceEntry}
@@ -242,6 +247,14 @@ const SelectedTapDetails = ({
       ) : (
         <div className={styles.expandedToolBar}>
           <div>
+            <button
+              className={styles.editButton}
+              aria-label="edit"
+              onClick={() => onStartEdit(resource)}
+              type="button"
+            >
+              Edit
+            </button>
             <IconButton
               color="primary"
               aria-label="share"

--- a/src/components/SelectedTapDetails/SelectedTapDetails.jsx
+++ b/src/components/SelectedTapDetails/SelectedTapDetails.jsx
@@ -1,11 +1,12 @@
-import { Button, Collapse, IconButton, SvgIcon } from '@mui/material';
+import React from 'react';
+import { Button, Collapse, IconButton, SvgIcon, Menu, MenuItem } from '@mui/material';
 import { styled } from '@mui/material/styles';
 import CloseIcon from '@mui/icons-material/Close';
+import MoreVertIcon from '@mui/icons-material/MoreVert';
 
 import DirectionIcon from 'icons/ArrowElbowUpRight';
 import CaretDownSvg from 'icons/CaretDown';
 import ExportSvg from 'icons/Export';
-import EditIcon from '@mui/icons-material/Edit';
 
 import FountainIcon from 'icons/CircleWaterIcon';
 import ForagingIcon from 'icons/CircleForagingIcon';
@@ -131,6 +132,21 @@ const SelectedTapDetails = ({
   setEditingResource,
   onStartEdit
 }) => {
+  const [menuAnchor, setMenuAnchor] = React.useState(null);
+
+  const handleMenuOpen = (event) => {
+    setMenuAnchor(event.currentTarget);
+  };
+
+  const handleMenuClose = () => {
+    setMenuAnchor(null);
+  };
+
+  const handleSuggestEdit = () => {
+    onStartEdit(selectedPlace);
+    handleMenuClose();
+  };
+
   /**
    * @type {ResourceEntry}
    */
@@ -250,23 +266,19 @@ const SelectedTapDetails = ({
           <div>
             <IconButton
               color="primary"
-              aria-label="edit"
-              onClick={() => onStartEdit(resource)}
+              aria-label="more options"
+              onClick={handleMenuOpen}
             >
-              <EditIcon />
+              <MoreVertIcon />
             </IconButton>
-            <IconButton
-              color="primary"
-              aria-label="share"
-              component="label"
-              onClick={toggleNativeShare}
+            <Menu
+              anchorEl={menuAnchor}
+              open={Boolean(menuAnchor)}
+              onClose={handleMenuClose}
             >
-              <ExportSvg />
-            </IconButton>
-            {/* TODO: Add this back in once we have real options! */}
-            {/* <IconButton color="primary" aria-label="more" component="label"> */}
-            {/*  <ThreeDotSvg /> */}
-            {/* </IconButton> */}
+              <MenuItem onClick={handleSuggestEdit}>Suggest Edit</MenuItem>
+              <MenuItem>Report</MenuItem>
+            </Menu>
           </div>
           {/* On mobile, show the minimize button. On desktop, show the close button */}
           {isMobile && (

--- a/src/components/SelectedTapDetails/SelectedTapDetails.jsx
+++ b/src/components/SelectedTapDetails/SelectedTapDetails.jsx
@@ -5,6 +5,7 @@ import CloseIcon from '@mui/icons-material/Close';
 import DirectionIcon from 'icons/ArrowElbowUpRight';
 import CaretDownSvg from 'icons/CaretDown';
 import ExportSvg from 'icons/Export';
+import EditIcon from '@mui/icons-material/Edit';
 
 import FountainIcon from 'icons/CircleWaterIcon';
 import ForagingIcon from 'icons/CircleForagingIcon';
@@ -247,14 +248,13 @@ const SelectedTapDetails = ({
       ) : (
         <div className={styles.expandedToolBar}>
           <div>
-            <button
-              className={styles.editButton}
+            <IconButton
+              color="primary"
               aria-label="edit"
               onClick={() => onStartEdit(resource)}
-              type="button"
             >
-              Edit
-            </button>
+              <EditIcon />
+            </IconButton>
             <IconButton
               color="primary"
               aria-label="share"

--- a/src/components/SelectedTapDetails/SelectedTapDetails.module.scss
+++ b/src/components/SelectedTapDetails/SelectedTapDetails.module.scss
@@ -98,6 +98,22 @@ $lighter-grey: #e9eef4;
     margin-bottom: 8px;
   }
 
+  .editButton {
+    background: none;
+    border: none;
+    color: #00A5EE;
+    font-size: 1em;
+    font-weight: 500;
+    padding: 0;
+    cursor: pointer;
+    text-decoration: none;
+    margin-right: 10px;
+
+    &:hover {
+      text-decoration: underline;
+    }
+  }
+
   .subtitles {
     line-height: 20px;
     margin-bottom: 0.1rem;

--- a/src/components/SelectedTapDetails/SelectedTapDetails.module.scss
+++ b/src/components/SelectedTapDetails/SelectedTapDetails.module.scss
@@ -98,6 +98,12 @@ $lighter-grey: #e9eef4;
     margin-bottom: 8px;
   }
 
+  .toolbarActions {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+  }
+
   .subtitles {
     line-height: 20px;
     margin-bottom: 0.1rem;

--- a/src/components/SelectedTapDetails/SelectedTapDetails.module.scss
+++ b/src/components/SelectedTapDetails/SelectedTapDetails.module.scss
@@ -98,22 +98,6 @@ $lighter-grey: #e9eef4;
     margin-bottom: 8px;
   }
 
-  .editButton {
-    background: none;
-    border: none;
-    color: #00A5EE;
-    font-size: 1em;
-    font-weight: 500;
-    padding: 0;
-    cursor: pointer;
-    text-decoration: none;
-    margin-right: 10px;
-
-    &:hover {
-      text-decoration: underline;
-    }
-  }
-
   .subtitles {
     line-height: 20px;
     margin-bottom: 0.1rem;


### PR DESCRIPTION
# Pull Request

## Change Summary

Added an Edit button to the resource detail modal that manages state for resource editing. The button stores the current resource and sets an editing flag for the Suggestion Form Dialog.

## Change Reason

Issue #648 requires implementing an Edit button to enable resource editing. This prepares the data for the Suggestion Form Dialog (#649) which will use the stored resource state to pre-fill the edit form.

## Changes

- `src/components/SelectedTap/SelectedTap.jsx`: Added `isEditing`, `editingResource` state and `handleStartEdit` function. Passed edit props to both mobile and desktop SelectedTapDetails.
- `src/components/SelectedTapDetails/SelectedTapDetails.jsx`: Updated component to accept edit props and added Edit button in toolbar.
- `src/components/SelectedTapDetails/SelectedTapDetails.module.scss`: Added `.editButton` styling with blue color (#00A5EE) and hover underline effect.
- **Hover state**: Text becomes underlined for visual feedback
- **On click**: Sets `isEditing` to true and stores resource in `editingResource` state

## Verification
<img width="611" height="567" alt="image" src="https://github.com/user-attachments/assets/fb4afdf4-f642-46f7-a4ed-d5eebc505fdf" />


Related Issues: #648