### PR TITLE
665: Add date modified label to resource cards

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "vite-tsconfig-paths": "^5.0.1"
   },
   "scripts": {
-    "start": "vite",
+    "start": "vite --host",
     "start:cypress": "VITE_CYPRESS_TEST=true yarn start",
     "build": "vite build",
     "testDataGen": "node cypress/testDataGenerator.js",

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "vite-tsconfig-paths": "^5.0.1"
   },
   "scripts": {
-    "start": "vite --host",
+    "start": "vite",
     "start:cypress": "VITE_CYPRESS_TEST=true yarn start",
     "build": "vite build",
     "testDataGen": "node cypress/testDataGenerator.js",

--- a/src/components/SelectedTapDetails/SelectedTapDetails.jsx
+++ b/src/components/SelectedTapDetails/SelectedTapDetails.jsx
@@ -338,10 +338,14 @@ const SelectedTapDetails = ({
             <span className={styles.walkTime}>{estWalkTime} min</span>
           </p>
         </div>
-        <div className={styles.dateModified}>
-          <h3>Last Modified</h3>
-          <p>{resourceLastUpdated}</p>
-        </div>
+        {
+          resourceLastUpdated && (
+            <div className={styles.dateModified}>
+              <h3>Last Modified</h3>
+              <p>{resourceLastUpdated}</p>
+            </div>
+          )
+        }
       </div>
 
       <div className={styles.tagGroup}>

--- a/src/components/SelectedTapDetails/SelectedTapDetails.jsx
+++ b/src/components/SelectedTapDetails/SelectedTapDetails.jsx
@@ -143,6 +143,7 @@ const SelectedTapDetails = ({
   let resourceTitle = '';
   let resourceSubtitleOne;
   let resourceSubtitleTwo;
+  let resourceLastUpdated;
 
   if (
     resource.name &&
@@ -164,6 +165,10 @@ const SelectedTapDetails = ({
     resource.longitude !== undefined
   ) {
     resourceTitle = latLongFormatted;
+  }
+
+  if (resource.last_modified) {
+    resourceLastUpdated = new Date(resource.last_modified).toDateString();
   }
 
   let icon;
@@ -332,6 +337,10 @@ const SelectedTapDetails = ({
             Est. walking time:{' '}
             <span className={styles.walkTime}>{estWalkTime} min</span>
           </p>
+        </div>
+        <div className={styles.dateModified}>
+          <h3>Last Modified</h3>
+          <p>{resourceLastUpdated}</p>
         </div>
       </div>
 

--- a/src/components/SelectedTapDetails/SelectedTapDetails.module.scss
+++ b/src/components/SelectedTapDetails/SelectedTapDetails.module.scss
@@ -69,6 +69,10 @@ $lighter-grey: #e9eef4;
         font-weight: 600;
       }
     }
+    .dateModified {
+      flex-grow: 1;
+      text-align: right;
+    }
   }
 
   .halfInfoExpand {


### PR DESCRIPTION
# Pull Request

## Change Summary

Summary of changes made. Adds a date modified label to resource cards

## Change Reason

Shows how information is currently being handled, and how currently it can be trusted.

## Verification [Optional]

<img width="1920" height="919" alt="image" src="https://github.com/user-attachments/assets/bcdce650-cf46-460e-beb4-8c123ae248db" />

Related Issue: Issue #665 

