### PR TITLE
Fixed: Map only moves when using two fingers on mobile

### DIFF
--- a/src/components/Map/Map.tsx
+++ b/src/components/Map/Map.tsx
@@ -1,7 +1,7 @@
 import {
   AdvancedMarker,
   Map as GoogleMap,
-  useMap
+  useMap,
 } from '@vis.gl/react-google-maps';
 import { usePostHog } from 'posthog-js/react';
 import { type CSSProperties } from 'react';
@@ -78,6 +78,7 @@ const Map = () => {
       mapTypeControl={false}
       rotateControl={false}
       fullscreenControl={false}
+      gestureHandling="greedy"
       defaultCenter={activeSearchLocation || CITY_HALL_LOCATION}
       mapId="DEMO_MAP_ID"
     >


### PR DESCRIPTION
# Pull Request

## Change Summary

- We now use `gesture handling: "greedy"` on our google map. 
  - This fixes a regression where you must use two fingers to move the map. Previously, you could use one finger

## Change Reason

We prefer using one finger to move the map

