### PR TITLE
change nearby behavior

### DIFF
--- a/src/components/Toolbar/Toolbar.tsx
+++ b/src/components/Toolbar/Toolbar.tsx
@@ -60,8 +60,8 @@ const Toolbar = () => {
       setSelectedResource(closest, prev);
       onChangeActiveSearchLocation(
         {
-          lat: location.lat,
-          lng: location.lng,
+          lat: closest.latitude,
+          lng: closest.longitude,
           placeId: closest.gp_id || undefined
         },
         prev


### PR DESCRIPTION
# Pull Request

## Change Summary

When the user clicks the "Nearby" button - it would remember either their location (if granted permission) or the active search location. We have changed this to remember the closest location instead

## Change Reason

It felt like a better UX once the user refreshed the page
