### PR TITLE
Fix search bar overlap on mobile

### DIFF
--- a/src/components/MobileHead/MobileHead.tsx
+++ b/src/components/MobileHead/MobileHead.tsx
@@ -29,7 +29,7 @@ const MobileHead = () => {
         sx={{
           backgroundColor: 'transparent',
           maxWidth: '100%',
-          zIndex: '9',
+          zIndex: theme => theme.zIndex.appBar,
           width: '100%'
         }}
       >

--- a/src/components/Overlay/Overlay.tsx
+++ b/src/components/Overlay/Overlay.tsx
@@ -34,13 +34,13 @@ const Overlay = () => {
       </Stack>
 
       <Stack
-        sx={theme => ({
+        sx={{
           position: 'fixed',
           bottom: '25px',
           left: '25px',
-          zIndex: theme.zIndex.appBar,
+          zIndex: 2,
           maxWidth: '765px'
-        })}
+        }}
         gap={2}
       >
         <Fade in={shouldShowSearchBar} mountOnEnter timeout={300}>


### PR DESCRIPTION
# Pull Request

## Change Summary

Updated `z-index` for the search bar wrapper to avoid overlapping with other elements

## Change Reason

On mobile, there was an overlap between the search bar and the open head menu

## Verification

Before:
<img width="384" height="257" alt="Screenshot 2026-04-14 at 8 20 51 PM" src="https://github.com/user-attachments/assets/d4544337-f72c-4bd5-844a-9131c09b948e" />

After:
<img width="331" height="299" alt="Screenshot 2026-04-14 at 8 21 01 PM" src="https://github.com/user-attachments/assets/1f84c980-daee-43d9-972e-2b194e443e76" />

