### PR TITLE
Show Provided By section in resource detail panel

### DIFF
--- a/src/components/ProvidedBy/ProvidedBy.tsx
+++ b/src/components/ProvidedBy/ProvidedBy.tsx
@@ -14,7 +14,6 @@ import {
 } from '@mui/material';
 import InfoOutlinedIcon from '@mui/icons-material/InfoOutlined';
 import { type Provider } from 'types/ResourceEntry';
-import useIsMobile from 'hooks/useIsMobile';
 
 type ProviderLogoProps = {
   provider: Provider;
@@ -67,28 +66,24 @@ type ProviderItemProps = {
   provider: Provider;
   onImageError: (logoUrl: string) => void;
   failedImages: Set<string>;
-  isMobile: boolean;
 };
 
 const ProviderItem = ({
   provider,
   onImageError,
-  failedImages,
-  isMobile
+  failedImages
 }: ProviderItemProps) => {
   const content = (
-    <Stack direction="row" alignItems="center" gap={isMobile ? 0 : 1.5}>
+    <Stack direction="row" alignItems="center" gap={1.5}>
       <ProviderLogo
         provider={provider}
         size={40}
         onError={onImageError}
         failedImages={failedImages}
       />
-      {!isMobile && (
-        <Typography fontSize={14} color="#2D3748" noWrap sx={{ maxWidth: 160 }}>
-          {provider.name}
-        </Typography>
-      )}
+      <Typography fontSize={14} color="#2D3748" noWrap sx={{ maxWidth: 160 }}>
+        {provider.name}
+      </Typography>
     </Stack>
   );
 
@@ -118,7 +113,6 @@ type ProvidedByProps = {
 const ProvidedBy = ({ providers = [], maxVisible = 2 }: ProvidedByProps) => {
   const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null);
   const [failedImages, setFailedImages] = useState<Set<string>>(new Set());
-  const isMobile = useIsMobile();
 
   if (providers.length === 0) {
     return null;
@@ -160,7 +154,6 @@ const ProvidedBy = ({ providers = [], maxVisible = 2 }: ProvidedByProps) => {
             provider={provider}
             onImageError={handleImageError}
             failedImages={failedImages}
-            isMobile={isMobile}
           />
         ))}
 

--- a/src/components/ProvidedBy/ProvidedBy.tsx
+++ b/src/components/ProvidedBy/ProvidedBy.tsx
@@ -81,7 +81,7 @@ const ProviderItem = ({
         onError={onImageError}
         failedImages={failedImages}
       />
-      <Typography fontSize={14} color="#2D3748" noWrap sx={{ maxWidth: 160 }}>
+      <Typography fontSize={14} color="#2D3748" noWrap>
         {provider.name}
       </Typography>
     </Stack>

--- a/src/components/ProvidedBy/ProvidedBy.tsx
+++ b/src/components/ProvidedBy/ProvidedBy.tsx
@@ -14,6 +14,7 @@ import {
 } from '@mui/material';
 import InfoOutlinedIcon from '@mui/icons-material/InfoOutlined';
 import { type Provider } from 'types/ResourceEntry';
+import useIsMobile from 'hooks/useIsMobile';
 
 type ProviderLogoProps = {
   provider: Provider;
@@ -66,24 +67,28 @@ type ProviderItemProps = {
   provider: Provider;
   onImageError: (logoUrl: string) => void;
   failedImages: Set<string>;
+  isMobile: boolean;
 };
 
 const ProviderItem = ({
   provider,
   onImageError,
-  failedImages
+  failedImages,
+  isMobile
 }: ProviderItemProps) => {
   const content = (
-    <Stack direction="row" alignItems="center" gap={1.5}>
+    <Stack direction="row" alignItems="center" gap={isMobile ? 0 : 1.5}>
       <ProviderLogo
         provider={provider}
         size={40}
         onError={onImageError}
         failedImages={failedImages}
       />
-      <Typography fontSize={14} color="#2D3748">
-        {provider.name}
-      </Typography>
+      {!isMobile && (
+        <Typography fontSize={14} color="#2D3748" noWrap sx={{ maxWidth: 160 }}>
+          {provider.name}
+        </Typography>
+      )}
     </Stack>
   );
 
@@ -113,6 +118,7 @@ type ProvidedByProps = {
 const ProvidedBy = ({ providers = [], maxVisible = 2 }: ProvidedByProps) => {
   const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null);
   const [failedImages, setFailedImages] = useState<Set<string>>(new Set());
+  const isMobile = useIsMobile();
 
   if (providers.length === 0) {
     return null;
@@ -154,6 +160,7 @@ const ProvidedBy = ({ providers = [], maxVisible = 2 }: ProvidedByProps) => {
             provider={provider}
             onImageError={handleImageError}
             failedImages={failedImages}
+            isMobile={isMobile}
           />
         ))}
 

--- a/src/components/ProvidedBy/ProvidedBy.tsx
+++ b/src/components/ProvidedBy/ProvidedBy.tsx
@@ -81,7 +81,7 @@ const ProviderItem = ({
         onError={onImageError}
         failedImages={failedImages}
       />
-      <Typography fontSize={14} color="#2D3748" noWrap>
+      <Typography fontSize={14} color="#2D3748">
         {provider.name}
       </Typography>
     </Stack>

--- a/src/components/SelectedResourceDetails/SelectedResourceDetails.tsx
+++ b/src/components/SelectedResourceDetails/SelectedResourceDetails.tsx
@@ -1,3 +1,5 @@
+// Adding comment to redo PR for testing -- remove later
+
 import {
   IconButton,
   Menu,

--- a/src/components/SelectedResourceDetails/SelectedResourceDetails.tsx
+++ b/src/components/SelectedResourceDetails/SelectedResourceDetails.tsx
@@ -208,6 +208,7 @@ const SelectedResourceDetails = ({
                   longitude={resource.longitude}
                 />
                 <EstimatedWalkingDuration selectedResource={resource} />
+                <ProvidedBy providers={providers} />
               </Stack>
             </Stack>
           </Stack>
@@ -220,7 +221,6 @@ const SelectedResourceDetails = ({
                 </Typography>
               </Stack>
             ) : null}
-            <ProvidedBy providers={providers} />
           </Stack>
         </Stack>
 


### PR DESCRIPTION
# Pull Request

## Change Summary

Moved the Provided By section to live below the directions/walk time layout instead of the two-column layout.

## Change Reason

The double-spaced two-column layout caused the Provided By section to feel out of place and cramped alongside other elements.

## Verification

desktop:
<img width="767" height="545" alt="Screenshot 2026-05-07 at 12 54 34 AM" src="https://github.com/user-attachments/assets/3c1cc0bf-57e9-4518-852b-4b5b3b6f4c4b" />

mobile: 
<img width="427" height="853" alt="image" src="https://github.com/user-attachments/assets/a9977015-8ad0-4157-bc43-17e1f21fd5fd" />
