### PR TITLE
Handle geolocation error messages

### DIFF
--- a/src/components/EstimatedWalkTime/EstimatedWalkTime.tsx
+++ b/src/components/EstimatedWalkTime/EstimatedWalkTime.tsx
@@ -2,6 +2,7 @@ import { Box, Stack, Typography } from '@mui/material';
 import { useWalkingDurationQuery } from 'hooks/queries/useWalkingDurationQuery';
 import type { ResourceEntry } from 'types/ResourceEntry';
 import UseMyLocationButton from 'components/UseMyLocationButton/UseMyLocationButton';
+import { useState } from 'react';
 
 type EstimatedWalkingDurationProps = {
   selectedResource: ResourceEntry;
@@ -10,6 +11,7 @@ type EstimatedWalkingDurationProps = {
 const EstimatedWalkingDuration = ({
   selectedResource
 }: EstimatedWalkingDurationProps) => {
+  const [locationErrorMessage, setLocationErrorMessage] = useState('');
   const {
     data: walkingDuration = null,
     isPending,
@@ -18,12 +20,17 @@ const EstimatedWalkingDuration = ({
   } = useWalkingDurationQuery({ selectedResource });
 
   if (isPending) {
-    <Typography color="#60718C" fontSize={14} fontWeight={400}>
-      Calculating walking duration...
-    </Typography>;
+    return (
+      <Typography color="#60718C" fontSize={14} fontWeight={400}>
+        Calculating walking duration...
+      </Typography>
+    );
   }
 
   const getDisplayValue = () => {
+    if (locationErrorMessage) {
+      return locationErrorMessage;
+    }
     if (isRefetching) {
       return 'Calculating...';
     }
@@ -55,8 +62,14 @@ const EstimatedWalkingDuration = ({
       {walkingDuration?.locationPermissionState === 'prompt' ? (
         <UseMyLocationButton
           // We refetch in both cases so that we can hide the button at the subsequent run
-          onError={() => refetch()}
-          onSuccess={() => refetch()}
+          onError={message => {
+            setLocationErrorMessage(message);
+            refetch();
+          }}
+          onSuccess={() => {
+            setLocationErrorMessage('');
+            refetch();
+          }}
         >
           Use my location
         </UseMyLocationButton>

--- a/src/components/UseMyLocationButton/UseMyLocationButton.tsx
+++ b/src/components/UseMyLocationButton/UseMyLocationButton.tsx
@@ -15,12 +15,13 @@ const UseMyLocationButton = ({
   children = 'Use my location instead'
 }: UseMyLocationButtonProps) => {
   const onUseMyLocationClick = async () => {
-    const [userLocation, isLocationServicesDisabled] = await getUserLocation();
+    const [value, isLocationServicesDisabled] = await getUserLocation();
+
     if (isLocationServicesDisabled) {
-      return onError('Location services must be enabled for this feature');
+      return onError(value);
     }
 
-    onSuccess(userLocation);
+    onSuccess(value);
   };
 
   return (

--- a/src/utils/getUserLocation.ts
+++ b/src/utils/getUserLocation.ts
@@ -1,5 +1,5 @@
 export type UserLocation = google.maps.LatLngLiteral;
-type GetUserLocationReturn = [UserLocation, false] | [null, true];
+type GetUserLocationReturn = [UserLocation, false] | [string, true];
 
 const getUserLocation = (): Promise<GetUserLocationReturn> =>
   new Promise<GetUserLocationReturn>(resolve =>
@@ -12,9 +12,9 @@ const getUserLocation = (): Promise<GetUserLocationReturn> =>
         const value: GetUserLocationReturn = [location, isError];
         resolve(value);
       },
-      () => {
+      error => {
         const isError = true;
-        const value: GetUserLocationReturn = [null, isError];
+        const value: GetUserLocationReturn = [error.message, isError];
         resolve(value);
       }
     )


### PR DESCRIPTION
# Pull Request

## Change Summary

Updated `getUserLocation` to return the browser geolocation error message instead of `null` when location access fails.

Before:
```ts
type GetUserLocationReturn = [UserLocation, false] | [null, true];
```

After:
```ts
type GetUserLocationReturn = [UserLocation, false] | [string, true];
```

This allows the error message returned from the browser to be passed through the application.

Updated `UseMyLocationButton.tsx` to use the returned value from `getUserLocation`.

Before, all location errors displayed a hardcoded message:
```ts
const onUseMyLocationClick = async () => {
  const [userLocation, isLocationServicesDisabled] = await getUserLocation();

  if (isLocationServicesDisabled) {
    return onError('Location services must be enabled for this feature');
  }

  onSuccess(userLocation);
};
```

After, the browser error message is passed to `onError`:
```ts
const onUseMyLocationClick = async () => {
  const [value, isLocationServicesDisabled] = await getUserLocation();

  if (isLocationServicesDisabled) {
    return onError(value);
  }

  onSuccess(value);
};
```

* Updated `EstimatedWalkTime.tsx` to store and display location error messages.

Added state:
```ts
const [locationErrorMessage, setLocationErrorMessage] = useState('');
```

Changed:
```tsx
onError={() => refetch()}
onSuccess={() => refetch()}
```

to:
```tsx
onError={message => {
  setLocationErrorMessage(message);
  refetch();
}}
onSuccess={() => {
  setLocationErrorMessage('');
  refetch();
}}
```

## Change Reason

Previously, when geolocation failed, the application only tracked that an error occurred and displayed a generic message. The actual browser geolocation error message was not being used.

These changes allow the browser-provided error message to flow from `getUserLocation`, through `UseMyLocationButton`, and into `EstimatedWalkTime.tsx`, where it can be displayed to the user.

This provides clearer feedback when location permissions fail or location services are unavailable.


## Verification [Optional]
<img width="1604" height="888" alt="Screenshot 2026-07-07 at 10 40 36 AM" src="https://github.com/user-attachments/assets/9935790d-8d47-481a-8ee5-4dc789e5feeb" />

[](url)

Related Issue: #<[732](https://github.com/phlask/phlask-map/issues/732)>

