### PR TITLE
Fixes/suggest edit forms

### DIFF
--- a/src/components/BathroomResourceForm/BathroomResourceForm.tsx
+++ b/src/components/BathroomResourceForm/BathroomResourceForm.tsx
@@ -18,6 +18,7 @@ type BathroomResourceFormProps = {
   defaultValues?: ResourceEntry | null;
   onSubmit: (values: FormValues) => void;
   onGoBack?: VoidFunction;
+  onClose?: VoidFunction;
   isSubmitting?: boolean;
 };
 
@@ -30,13 +31,15 @@ const BathroomResourceForm = ({
   defaultValues,
   isSubmitting,
   onSubmit,
-  onGoBack
+  onGoBack,
+  onClose: onCloseProp
 }: BathroomResourceFormProps) => {
   const { setToolbarModal } = useToolbarContext();
   const onClose = () => {
     if (onGoBack) {
       onGoBack();
     }
+    onCloseProp?.();
 
     setToolbarModal(null);
   };

--- a/src/components/EditResourceForm/EditResourceForm.tsx
+++ b/src/components/EditResourceForm/EditResourceForm.tsx
@@ -48,29 +48,37 @@ const EditResourceForm = () => {
   const resourceForms = {
     [ResourceType.WATER]: (
       <WaterResourceForm
+        key={resourceEditCandidate.id}
         defaultValues={resourceEditCandidate}
         isSubmitting={isPending}
+        onClose={() => setResourceEditCandidate(null)}
         onSubmit={onSubmit}
       />
     ),
     [ResourceType.FOOD]: (
       <FoodResourceForm
+        key={resourceEditCandidate.id}
         defaultValues={resourceEditCandidate}
         isSubmitting={isPending}
+        onClose={() => setResourceEditCandidate(null)}
         onSubmit={onSubmit}
       />
     ),
     [ResourceType.FORAGE]: (
       <ForageResourceForm
+        key={resourceEditCandidate.id}
         defaultValues={resourceEditCandidate}
         isSubmitting={isPending}
+        onClose={() => setResourceEditCandidate(null)}
         onSubmit={onSubmit}
       />
     ),
     [ResourceType.BATHROOM]: (
       <BathroomResourceForm
+        key={resourceEditCandidate.id}
         defaultValues={resourceEditCandidate}
         isSubmitting={isPending}
+        onClose={() => setResourceEditCandidate(null)}
         onSubmit={onSubmit}
       />
     )

--- a/src/components/FoodResourceForm/FoodResourceForm.tsx
+++ b/src/components/FoodResourceForm/FoodResourceForm.tsx
@@ -26,6 +26,7 @@ type FoodResourceFormProps = {
   defaultValues?: ResourceEntry | null;
   onSubmit: (values: FormValues) => void;
   onGoBack?: VoidFunction;
+  onClose?: VoidFunction;
   isSubmitting?: boolean;
 };
 
@@ -36,6 +37,7 @@ const FoodResourceForm = ({
   defaultValues = null,
   isSubmitting = false,
   onGoBack,
+  onClose: onCloseProp,
   onSubmit
 }: FoodResourceFormProps) => {
   const { setToolbarModal } = useToolbarContext();
@@ -43,6 +45,7 @@ const FoodResourceForm = ({
     if (onGoBack) {
       onGoBack();
     }
+    onCloseProp?.();
 
     setToolbarModal(null);
   };

--- a/src/components/ForageResourceForm/ForageResourceForm.tsx
+++ b/src/components/ForageResourceForm/ForageResourceForm.tsx
@@ -20,6 +20,7 @@ type ForageResourceFormProps = {
   defaultValues?: ResourceEntry | null;
   onSubmit: (values: FormValues) => void;
   onGoBack?: VoidFunction;
+  onClose?: VoidFunction;
   isSubmitting?: boolean;
 };
 
@@ -30,13 +31,15 @@ const ForageResourceForm = ({
   defaultValues,
   isSubmitting,
   onSubmit,
-  onGoBack
+  onGoBack,
+  onClose: onCloseProp
 }: ForageResourceFormProps) => {
   const { setToolbarModal } = useToolbarContext();
   const onClose = () => {
     if (onGoBack) {
       onGoBack();
     }
+    onCloseProp?.();
 
     setToolbarModal(null);
   };

--- a/src/components/WaterResourceForm/WaterResourceForm.tsx
+++ b/src/components/WaterResourceForm/WaterResourceForm.tsx
@@ -21,6 +21,7 @@ type WaterResourceFormProps = {
   defaultValues?: ResourceEntry | null;
   onSubmit: (values: FormValues) => void;
   onGoBack?: VoidFunction;
+  onClose?: VoidFunction;
   isSubmitting?: boolean;
 };
 
@@ -31,6 +32,7 @@ const WaterResourceForm = ({
   defaultValues = null,
   isSubmitting = false,
   onGoBack,
+  onClose: onCloseProp,
   onSubmit
 }: WaterResourceFormProps) => {
   const { setToolbarModal } = useToolbarContext();
@@ -38,6 +40,7 @@ const WaterResourceForm = ({
     if (onGoBack) {
       onGoBack();
     }
+    onCloseProp?.();
 
     setToolbarModal(null);
   };

--- a/src/components/forms/FormAddressField/FormResourceAddressField.tsx
+++ b/src/components/forms/FormAddressField/FormResourceAddressField.tsx
@@ -16,8 +16,15 @@ const FormResourceAddressField = ({
 }: FormResourceAddressFieldProps) => {
   const { suggestions, isFetching, onChange, onDebouncedChange } =
     useGooglePlacesAutocomplete();
-  const { inputRef, error, onClear, setAddressError, setAddressValues } =
-    useAddressFormControllers();
+  const {
+    inputRef,
+    addressValue,
+    setAddressInput,
+    error,
+    onClear,
+    setAddressError,
+    setAddressValues
+  } = useAddressFormControllers();
 
   const onSelect = async (place: google.maps.places.Place) => {
     const googlePlacesId = place.id;
@@ -77,6 +84,7 @@ const FormResourceAddressField = ({
     }
 
     onChange(firstPlace.formattedAddress);
+    setAddressInput(firstPlace.formattedAddress);
   };
 
   return (
@@ -84,7 +92,10 @@ const FormResourceAddressField = ({
       openOnFocus
       options={suggestions}
       fullWidth={fullWidth}
-      onInputChange={(_event, value) => {
+      inputValue={addressValue ?? ''}
+      onInputChange={(_event, value, reason) => {
+        if (reason === 'reset') return;
+        setAddressInput(value);
         onDebouncedChange(value);
       }}
       loading={isFetching}

--- a/src/hooks/useAddressFormControllers.ts
+++ b/src/hooks/useAddressFormControllers.ts
@@ -44,6 +44,8 @@ const useAddressFormControllers = () => {
 
   return {
     inputRef: addressController.field.ref,
+    addressValue: addressController.field.value,
+    setAddressInput: (value: string) => addressController.field.onChange(value),
     error: addressController.fieldState.error,
     setAddressValues,
     setAddressError,

--- a/src/schemas/baseResourceSchema.ts
+++ b/src/schemas/baseResourceSchema.ts
@@ -30,7 +30,7 @@ const baseResourceSchema = z.object({
   verification: z
     .object({
       verified: z.boolean().default(false),
-      last_modified: z.iso.datetime().default(() => new Date().toISOString()),
+      last_modified: z.iso.datetime().catch(() => new Date().toISOString()),
       verifier: z.string().default('')
     })
     .default(() => ({
@@ -51,7 +51,7 @@ const baseResourceSchema = z.object({
   ),
   status: z
     .enum(['OPERATIONAL', 'TEMPORARILY_CLOSED', 'PERMANENTLY_CLOSED', 'HIDDEN'])
-    .default('OPERATIONAL')
+    .catch('OPERATIONAL')
 });
 
 export type BaseResourceSchema = z.infer<typeof baseResourceSchema>;

--- a/src/schemas/bathroomResourceSchema.ts
+++ b/src/schemas/bathroomResourceSchema.ts
@@ -8,16 +8,18 @@ const bathroomResourceSchema = baseResourceSchema.extend({
     .default(ResourceType.BATHROOM),
   bathroom: z
     .object({
-      tags: z.array(
-        z.enum([
-          'WHEELCHAIR_ACCESSIBLE',
-          'GENDER_NEUTRAL',
-          'CHANGING_TABLE',
-          'SINGLE_OCCUPANCY',
-          'HAS_FOUNTAIN',
-          'FAMILY'
-        ])
-      )
+      tags: z
+        .array(
+          z.enum([
+            'WHEELCHAIR_ACCESSIBLE',
+            'GENDER_NEUTRAL',
+            'CHANGING_TABLE',
+            'SINGLE_OCCUPANCY',
+            'HAS_FOUNTAIN',
+            'FAMILY'
+          ])
+        )
+        .default([])
     })
     .default({ tags: [] })
 });

--- a/src/schemas/foodResourceSchema.ts
+++ b/src/schemas/foodResourceSchema.ts
@@ -6,9 +6,13 @@ const foodResourceSchema = baseResourceSchema.extend({
   resource_type: z.literal(ResourceType.FOOD).default(ResourceType.FOOD),
   food: z
     .object({
-      food_type: z.array(z.enum(['PERISHABLE', 'NON_PERISHABLE', 'PREPARED'])),
-      distribution_type: z.array(z.enum(['EAT_ON_SITE', 'DELIVERY', 'PICKUP'])),
-      organization_name: z.string(),
+      food_type: z
+        .array(z.enum(['PERISHABLE', 'NON_PERISHABLE', 'PREPARED']))
+        .default([]),
+      distribution_type: z
+        .array(z.enum(['EAT_ON_SITE', 'DELIVERY', 'PICKUP']))
+        .default([]),
+      organization_name: z.string().default(''),
       organization_url: z
         .union([
           z
@@ -20,13 +24,10 @@ const foodResourceSchema = baseResourceSchema.extend({
           z.literal('')
         ])
         .default(''),
-      organization_type: z.enum([
-        'GOVERNMENT',
-        'BUSINESS',
-        'NON_PROFIT',
-        'UNSURE'
-      ]),
-      tags: z.array(z.string())
+      organization_type: z
+        .enum(['GOVERNMENT', 'BUSINESS', 'NON_PROFIT', 'UNSURE'])
+        .default('UNSURE'),
+      tags: z.array(z.string()).default([])
     })
     .default({
       food_type: [],

--- a/src/schemas/foragingResourceSchema.ts
+++ b/src/schemas/foragingResourceSchema.ts
@@ -6,10 +6,12 @@ const foragingResourceSchema = baseResourceSchema.extend({
   resource_type: z.literal(ResourceType.FORAGE).default(ResourceType.FORAGE),
   forage: z
     .object({
-      forage_type: z.array(
-        z.enum(['NUT', 'FRUIT', 'LEAVES', 'BARK', 'FLOWERS'])
-      ),
-      tags: z.array(z.enum(['MEDICINAL', 'IN_SEASON', 'COMMUNITY_GARDEN']))
+      forage_type: z
+        .array(z.enum(['NUT', 'FRUIT', 'LEAVES', 'BARK', 'FLOWERS']))
+        .default([]),
+      tags: z
+        .array(z.enum(['MEDICINAL', 'IN_SEASON', 'COMMUNITY_GARDEN']))
+        .default([])
     })
     .default({ forage_type: [], tags: [] })
 });


### PR DESCRIPTION
# Pull Request

## Change Summary

- Address prefill for all Suggest Edits
- Close-X --- fixes: close an edit midway, then click Add Site → you'd get the old edit form instead of a blank Add form.
- Remount per resource (key)  --- fixes: open Suggest Edit on resource B right after A → B showed A's data.
- The Foraging and Food resource 'Suggest edits' were crashing without a catch, updated the schema and added defaults.


Related: #674 #678 #753 